### PR TITLE
Fix Broken Game Sounds on Large ID NPCS

### DIFF
--- a/2006Scape Server/src/main/java/com/rs2/game/content/music/sound/CombatSounds.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/music/sound/CombatSounds.java
@@ -163,7 +163,14 @@ public class CombatSounds {
 	}
 
 	public static String GetNpcName(int NpcID) {
-		return NpcHandler.NpcList[NpcID].npcName;
+		for (int i = 0; i < NpcHandler.NpcList.length; i++) {
+            if (NpcHandler.NpcList[i] != null) {
+                if (NpcHandler.NpcList[i].npcId == NpcID) {
+                    return NpcHandler.NpcList[i].npcName;
+                }
+            }
+        }
+		return "";
 	}
 
 	public static String getItemName(int ItemID) {


### PR DESCRIPTION
- Replace get NPC name associate array method to indexed array method

The current code uses a `GetNpcName` method which incorrectly assumes that the NPC List is an associate array where the ID is the index. This is not the case as the index is actually incremental.

While I would have rather changed the NPC List to be an associate array, as in the future writing code like this is not scalable for thousands of people on each server with thousands of NPC's, however that would require a rewrite of other methods too.

I found this issue when I attempted to kill Giant Mole which has an ID of 3340 but an array index of 2773. There is no npc with the index of 3340 so it crashed the server.

![image](https://user-images.githubusercontent.com/2869411/114944245-551cc380-9e9b-11eb-91f1-be7698e4adaa.png)
