### PR TITLE
East falador staircase to mine teleport bug

### DIFF
--- a/2006Scape Server/src/main/java/com/rs2/game/objects/impl/Climbing.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/objects/impl/Climbing.java
@@ -229,6 +229,8 @@ public class Climbing {
 				} else if (client.objectX == 2603 && client.objectY == 3078) {
 					client.getPlayerAssistant().feature("using this staircase");
 					client.resetWalkingQueue();
+				} else if (client.objectX == 3058 && client.objectY == 3376) {
+				    client.resetWalkingQueue();
 				} else if (client.absX != 3186) {
 					client.getPlayerAssistant().movePlayer(client.absX,
 							client.absY + 6393, 0);


### PR DESCRIPTION
East falador staircase was falling into the last if which was teleporting the player to a void. This fixes #452 however looking at the code the last catch block is probably causing issues else where.