### PR TITLE
Bug Fixes, Lost City Fixes

### DIFF
--- a/2006Scape Server/data/cfg/npcdrops.json
+++ b/2006Scape Server/data/cfg/npcdrops.json
@@ -6211,7 +6211,7 @@
       },
       {
         "item_id": 1351,
-        "chance": 16,
+        "chance": 64,
         "amounts": [
           1,
           1
@@ -8480,26 +8480,18 @@
       },
       {
         "item_id": 995,
-        "chance": 8,
+        "chance": 32,
         "amounts": [
-          5,
-          5
+          1,
+          26
         ]
       },
       {
-        "item_id": 2347,
-        "chance": 16,
+        "item_id": 1203,
+        "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 995,
-        "chance": 32,
-        "amounts": [
-          9,
-          15
         ]
       },
       {
@@ -8511,11 +8503,35 @@
         ]
       },
       {
+        "item_id": 1139,
+        "chance": 32,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 556,
+        "chance": 32,
+        "amounts": [
+          2,
+          4
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          2,
+          11
         ]
       },
       {
@@ -8532,14 +8548,6 @@
         "amounts": [
           6,
           6
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          7,
-          7
         ]
       },
       {
@@ -8567,7 +8575,7 @@
         ]
       },
       {
-        "item_id": 1237,
+        "item_id": 1155,
         "chance": 64,
         "amounts": [
           1,
@@ -8575,7 +8583,47 @@
         ]
       },
       {
-        "item_id": 1917,
+        "item_id": 1277,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1291,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 884,
+        "chance": 64,
+        "amounts": [
+          3,
+          6
+        ]
+      },
+      {
+        "item_id": 1103,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1381,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1189,
         "chance": 64,
         "amounts": [
           1,
@@ -8591,11 +8639,107 @@
         ]
       },
       {
+        "item_id": 1442,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
+        ]
+      },
+      {
+        "item_id": 1440,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1351,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1321,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1153,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1129,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1007,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 562,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 561,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1448,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 946,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 438,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
         ]
       }
     ]
@@ -8709,6 +8853,14 @@
       },
       {
         "item_id": 1155,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1277,
         "chance": 64,
         "amounts": [
           1,
@@ -96296,26 +96448,18 @@
       },
       {
         "item_id": 995,
-        "chance": 8,
+        "chance": 32,
         "amounts": [
-          5,
-          5
+          1,
+          26
         ]
       },
       {
-        "item_id": 2347,
-        "chance": 16,
+        "item_id": 1203,
+        "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 995,
-        "chance": 32,
-        "amounts": [
-          9,
-          15
         ]
       },
       {
@@ -96327,11 +96471,35 @@
         ]
       },
       {
+        "item_id": 1139,
+        "chance": 32,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 556,
+        "chance": 32,
+        "amounts": [
+          2,
+          4
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          2,
+          11
         ]
       },
       {
@@ -96348,14 +96516,6 @@
         "amounts": [
           6,
           6
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          7,
-          7
         ]
       },
       {
@@ -96383,7 +96543,7 @@
         ]
       },
       {
-        "item_id": 1237,
+        "item_id": 1155,
         "chance": 64,
         "amounts": [
           1,
@@ -96391,7 +96551,47 @@
         ]
       },
       {
-        "item_id": 1917,
+        "item_id": 1277,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1291,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 884,
+        "chance": 64,
+        "amounts": [
+          3,
+          6
+        ]
+      },
+      {
+        "item_id": 1103,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1381,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1189,
         "chance": 64,
         "amounts": [
           1,
@@ -96407,11 +96607,107 @@
         ]
       },
       {
+        "item_id": 1442,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
+        ]
+      },
+      {
+        "item_id": 1440,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1351,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1321,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1153,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1129,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1007,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 562,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 561,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1448,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 946,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 438,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
         ]
       }
     ]
@@ -96429,26 +96725,18 @@
       },
       {
         "item_id": 995,
-        "chance": 8,
+        "chance": 32,
         "amounts": [
-          5,
-          5
+          1,
+          26
         ]
       },
       {
-        "item_id": 2347,
-        "chance": 16,
+        "item_id": 1203,
+        "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 995,
-        "chance": 32,
-        "amounts": [
-          9,
-          15
         ]
       },
       {
@@ -96460,11 +96748,35 @@
         ]
       },
       {
+        "item_id": 1139,
+        "chance": 32,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 556,
+        "chance": 32,
+        "amounts": [
+          2,
+          4
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          2,
+          11
         ]
       },
       {
@@ -96481,14 +96793,6 @@
         "amounts": [
           6,
           6
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          7,
-          7
         ]
       },
       {
@@ -96516,7 +96820,7 @@
         ]
       },
       {
-        "item_id": 1237,
+        "item_id": 1155,
         "chance": 64,
         "amounts": [
           1,
@@ -96524,7 +96828,47 @@
         ]
       },
       {
-        "item_id": 1917,
+        "item_id": 1277,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1291,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 884,
+        "chance": 64,
+        "amounts": [
+          3,
+          6
+        ]
+      },
+      {
+        "item_id": 1103,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1381,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1189,
         "chance": 64,
         "amounts": [
           1,
@@ -96540,11 +96884,107 @@
         ]
       },
       {
+        "item_id": 1442,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
+        ]
+      },
+      {
+        "item_id": 1440,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1351,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1321,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1153,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1129,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1007,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 562,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 561,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1448,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 946,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 438,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
         ]
       }
     ]
@@ -96562,26 +97002,18 @@
       },
       {
         "item_id": 995,
-        "chance": 8,
+        "chance": 32,
         "amounts": [
-          5,
-          5
+          1,
+          26
         ]
       },
       {
-        "item_id": 2347,
-        "chance": 16,
+        "item_id": 1203,
+        "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 995,
-        "chance": 32,
-        "amounts": [
-          9,
-          15
         ]
       },
       {
@@ -96593,11 +97025,35 @@
         ]
       },
       {
+        "item_id": 1139,
+        "chance": 32,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 556,
+        "chance": 32,
+        "amounts": [
+          2,
+          4
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          2,
+          11
         ]
       },
       {
@@ -96614,14 +97070,6 @@
         "amounts": [
           6,
           6
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          7,
-          7
         ]
       },
       {
@@ -96649,7 +97097,7 @@
         ]
       },
       {
-        "item_id": 1237,
+        "item_id": 1155,
         "chance": 64,
         "amounts": [
           1,
@@ -96657,7 +97105,47 @@
         ]
       },
       {
-        "item_id": 1917,
+        "item_id": 1277,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1291,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 884,
+        "chance": 64,
+        "amounts": [
+          3,
+          6
+        ]
+      },
+      {
+        "item_id": 1103,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1381,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1189,
         "chance": 64,
         "amounts": [
           1,
@@ -96673,11 +97161,107 @@
         ]
       },
       {
+        "item_id": 1442,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
+        ]
+      },
+      {
+        "item_id": 1440,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1351,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1321,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1153,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1129,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1007,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 562,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 561,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1448,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 946,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 438,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
         ]
       }
     ]
@@ -96695,26 +97279,18 @@
       },
       {
         "item_id": 995,
-        "chance": 8,
+        "chance": 32,
         "amounts": [
-          5,
-          5
+          1,
+          26
         ]
       },
       {
-        "item_id": 2347,
-        "chance": 16,
+        "item_id": 1203,
+        "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 995,
-        "chance": 32,
-        "amounts": [
-          9,
-          15
         ]
       },
       {
@@ -96726,11 +97302,35 @@
         ]
       },
       {
+        "item_id": 1139,
+        "chance": 32,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 556,
+        "chance": 32,
+        "amounts": [
+          2,
+          4
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          2,
+          11
         ]
       },
       {
@@ -96747,14 +97347,6 @@
         "amounts": [
           6,
           6
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          7,
-          7
         ]
       },
       {
@@ -96782,7 +97374,7 @@
         ]
       },
       {
-        "item_id": 1237,
+        "item_id": 1155,
         "chance": 64,
         "amounts": [
           1,
@@ -96790,7 +97382,47 @@
         ]
       },
       {
-        "item_id": 1917,
+        "item_id": 1277,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1291,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 884,
+        "chance": 64,
+        "amounts": [
+          3,
+          6
+        ]
+      },
+      {
+        "item_id": 1103,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1381,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1189,
         "chance": 64,
         "amounts": [
           1,
@@ -96806,11 +97438,107 @@
         ]
       },
       {
+        "item_id": 1442,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
+        ]
+      },
+      {
+        "item_id": 1440,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1351,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1321,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1153,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1129,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1007,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 562,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 561,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1448,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 946,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 438,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
         ]
       }
     ]
@@ -96828,26 +97556,18 @@
       },
       {
         "item_id": 995,
-        "chance": 8,
+        "chance": 32,
         "amounts": [
-          5,
-          5
+          1,
+          26
         ]
       },
       {
-        "item_id": 2347,
-        "chance": 16,
+        "item_id": 1203,
+        "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 995,
-        "chance": 32,
-        "amounts": [
-          9,
-          15
         ]
       },
       {
@@ -96859,11 +97579,35 @@
         ]
       },
       {
+        "item_id": 1139,
+        "chance": 32,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 556,
+        "chance": 32,
+        "amounts": [
+          2,
+          4
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          2,
+          11
         ]
       },
       {
@@ -96880,14 +97624,6 @@
         "amounts": [
           6,
           6
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          7,
-          7
         ]
       },
       {
@@ -96915,7 +97651,7 @@
         ]
       },
       {
-        "item_id": 1237,
+        "item_id": 1155,
         "chance": 64,
         "amounts": [
           1,
@@ -96923,7 +97659,47 @@
         ]
       },
       {
-        "item_id": 1917,
+        "item_id": 1277,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1291,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 884,
+        "chance": 64,
+        "amounts": [
+          3,
+          6
+        ]
+      },
+      {
+        "item_id": 1103,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1381,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1189,
         "chance": 64,
         "amounts": [
           1,
@@ -96939,11 +97715,107 @@
         ]
       },
       {
+        "item_id": 1442,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
+        ]
+      },
+      {
+        "item_id": 1440,
+        "chance": 64,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1351,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1321,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1153,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1129,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1007,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 562,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 561,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 1448,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 946,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 438,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
         ]
       }
     ]
@@ -138129,15 +139001,7 @@
       },
       {
         "item_id": 6739,
-        "chance": 128,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 6733,
-        "chance": 128,
+        "chance": 256,
         "amounts": [
           1,
           1
@@ -138241,6 +139105,14 @@
       },
       {
         "item_id": 3749,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 6733,
         "chance": 256,
         "amounts": [
           1,
@@ -138518,7 +139390,7 @@
       },
       {
         "item_id": 6739,
-        "chance": 128,
+        "chance": 256,
         "amounts": [
           1,
           1
@@ -138598,6 +139470,14 @@
       },
       {
         "item_id": 6139,
+        "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 6731,
         "chance": 256,
         "amounts": [
           1,
@@ -138719,14 +139599,6 @@
       {
         "item_id": 5303,
         "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 6731,
-        "chance": 128,
         "amounts": [
           1,
           1

--- a/2006Scape Server/data/cfg/npcdrops.json
+++ b/2006Scape Server/data/cfg/npcdrops.json
@@ -139112,14 +139112,6 @@
         ]
       },
       {
-        "item_id": 6733,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": -1,
         "chance": 256,
         "amounts": [
@@ -139470,14 +139462,6 @@
       },
       {
         "item_id": 6139,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 6731,
         "chance": 256,
         "amounts": [
           1,

--- a/2006Scape Server/data/cfg/npcdrops.json
+++ b/2006Scape Server/data/cfg/npcdrops.json
@@ -8480,18 +8480,26 @@
       },
       {
         "item_id": 995,
-        "chance": 32,
+        "chance": 8,
         "amounts": [
-          1,
-          26
+          5,
+          5
         ]
       },
       {
-        "item_id": 1203,
-        "chance": 32,
+        "item_id": 2347,
+        "chance": 16,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 995,
+        "chance": 32,
+        "amounts": [
+          9,
+          15
         ]
       },
       {
@@ -8503,35 +8511,11 @@
         ]
       },
       {
-        "item_id": 1139,
-        "chance": 32,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 556,
-        "chance": 32,
-        "amounts": [
-          2,
-          4
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          2,
-          11
         ]
       },
       {
@@ -8548,6 +8532,14 @@
         "amounts": [
           6,
           6
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          7,
+          7
         ]
       },
       {
@@ -8575,7 +8567,7 @@
         ]
       },
       {
-        "item_id": 1155,
+        "item_id": 1237,
         "chance": 64,
         "amounts": [
           1,
@@ -8583,47 +8575,7 @@
         ]
       },
       {
-        "item_id": 1277,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1291,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 884,
-        "chance": 64,
-        "amounts": [
-          3,
-          6
-        ]
-      },
-      {
-        "item_id": 1103,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1381,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1189,
+        "item_id": 1917,
         "chance": 64,
         "amounts": [
           1,
@@ -8639,107 +8591,11 @@
         ]
       },
       {
-        "item_id": 1442,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
-        ]
-      },
-      {
-        "item_id": 1440,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1351,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1321,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1153,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1129,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1007,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 562,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 561,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1448,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 946,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 438,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
         ]
       }
     ]
@@ -8853,14 +8709,6 @@
       },
       {
         "item_id": 1155,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1277,
         "chance": 64,
         "amounts": [
           1,
@@ -96448,18 +96296,26 @@
       },
       {
         "item_id": 995,
-        "chance": 32,
+        "chance": 8,
         "amounts": [
-          1,
-          26
+          5,
+          5
         ]
       },
       {
-        "item_id": 1203,
-        "chance": 32,
+        "item_id": 2347,
+        "chance": 16,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 995,
+        "chance": 32,
+        "amounts": [
+          9,
+          15
         ]
       },
       {
@@ -96471,35 +96327,11 @@
         ]
       },
       {
-        "item_id": 1139,
-        "chance": 32,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 556,
-        "chance": 32,
-        "amounts": [
-          2,
-          4
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          2,
-          11
         ]
       },
       {
@@ -96516,6 +96348,14 @@
         "amounts": [
           6,
           6
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          7,
+          7
         ]
       },
       {
@@ -96543,7 +96383,7 @@
         ]
       },
       {
-        "item_id": 1155,
+        "item_id": 1237,
         "chance": 64,
         "amounts": [
           1,
@@ -96551,47 +96391,7 @@
         ]
       },
       {
-        "item_id": 1277,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1291,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 884,
-        "chance": 64,
-        "amounts": [
-          3,
-          6
-        ]
-      },
-      {
-        "item_id": 1103,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1381,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1189,
+        "item_id": 1917,
         "chance": 64,
         "amounts": [
           1,
@@ -96607,107 +96407,11 @@
         ]
       },
       {
-        "item_id": 1442,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
-        ]
-      },
-      {
-        "item_id": 1440,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1351,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1321,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1153,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1129,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1007,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 562,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 561,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1448,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 946,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 438,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
         ]
       }
     ]
@@ -96725,18 +96429,26 @@
       },
       {
         "item_id": 995,
-        "chance": 32,
+        "chance": 8,
         "amounts": [
-          1,
-          26
+          5,
+          5
         ]
       },
       {
-        "item_id": 1203,
-        "chance": 32,
+        "item_id": 2347,
+        "chance": 16,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 995,
+        "chance": 32,
+        "amounts": [
+          9,
+          15
         ]
       },
       {
@@ -96748,35 +96460,11 @@
         ]
       },
       {
-        "item_id": 1139,
-        "chance": 32,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 556,
-        "chance": 32,
-        "amounts": [
-          2,
-          4
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          2,
-          11
         ]
       },
       {
@@ -96793,6 +96481,14 @@
         "amounts": [
           6,
           6
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          7,
+          7
         ]
       },
       {
@@ -96820,7 +96516,7 @@
         ]
       },
       {
-        "item_id": 1155,
+        "item_id": 1237,
         "chance": 64,
         "amounts": [
           1,
@@ -96828,47 +96524,7 @@
         ]
       },
       {
-        "item_id": 1277,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1291,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 884,
-        "chance": 64,
-        "amounts": [
-          3,
-          6
-        ]
-      },
-      {
-        "item_id": 1103,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1381,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1189,
+        "item_id": 1917,
         "chance": 64,
         "amounts": [
           1,
@@ -96884,107 +96540,11 @@
         ]
       },
       {
-        "item_id": 1442,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
-        ]
-      },
-      {
-        "item_id": 1440,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1351,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1321,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1153,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1129,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1007,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 562,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 561,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1448,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 946,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 438,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
         ]
       }
     ]
@@ -97002,18 +96562,26 @@
       },
       {
         "item_id": 995,
-        "chance": 32,
+        "chance": 8,
         "amounts": [
-          1,
-          26
+          5,
+          5
         ]
       },
       {
-        "item_id": 1203,
-        "chance": 32,
+        "item_id": 2347,
+        "chance": 16,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 995,
+        "chance": 32,
+        "amounts": [
+          9,
+          15
         ]
       },
       {
@@ -97025,35 +96593,11 @@
         ]
       },
       {
-        "item_id": 1139,
-        "chance": 32,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 556,
-        "chance": 32,
-        "amounts": [
-          2,
-          4
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          2,
-          11
         ]
       },
       {
@@ -97070,6 +96614,14 @@
         "amounts": [
           6,
           6
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          7,
+          7
         ]
       },
       {
@@ -97097,7 +96649,7 @@
         ]
       },
       {
-        "item_id": 1155,
+        "item_id": 1237,
         "chance": 64,
         "amounts": [
           1,
@@ -97105,47 +96657,7 @@
         ]
       },
       {
-        "item_id": 1277,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1291,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 884,
-        "chance": 64,
-        "amounts": [
-          3,
-          6
-        ]
-      },
-      {
-        "item_id": 1103,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1381,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1189,
+        "item_id": 1917,
         "chance": 64,
         "amounts": [
           1,
@@ -97161,107 +96673,11 @@
         ]
       },
       {
-        "item_id": 1442,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
-        ]
-      },
-      {
-        "item_id": 1440,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1351,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1321,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1153,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1129,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1007,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 562,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 561,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1448,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 946,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 438,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
         ]
       }
     ]
@@ -97279,18 +96695,26 @@
       },
       {
         "item_id": 995,
-        "chance": 32,
+        "chance": 8,
         "amounts": [
-          1,
-          26
+          5,
+          5
         ]
       },
       {
-        "item_id": 1203,
-        "chance": 32,
+        "item_id": 2347,
+        "chance": 16,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 995,
+        "chance": 32,
+        "amounts": [
+          9,
+          15
         ]
       },
       {
@@ -97302,35 +96726,11 @@
         ]
       },
       {
-        "item_id": 1139,
-        "chance": 32,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 556,
-        "chance": 32,
-        "amounts": [
-          2,
-          4
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          2,
-          11
         ]
       },
       {
@@ -97347,6 +96747,14 @@
         "amounts": [
           6,
           6
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          7,
+          7
         ]
       },
       {
@@ -97374,7 +96782,7 @@
         ]
       },
       {
-        "item_id": 1155,
+        "item_id": 1237,
         "chance": 64,
         "amounts": [
           1,
@@ -97382,47 +96790,7 @@
         ]
       },
       {
-        "item_id": 1277,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1291,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 884,
-        "chance": 64,
-        "amounts": [
-          3,
-          6
-        ]
-      },
-      {
-        "item_id": 1103,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1381,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1189,
+        "item_id": 1917,
         "chance": 64,
         "amounts": [
           1,
@@ -97438,107 +96806,11 @@
         ]
       },
       {
-        "item_id": 1442,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
-        ]
-      },
-      {
-        "item_id": 1440,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1351,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1321,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1153,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1129,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1007,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 562,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 561,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1448,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 946,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 438,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
         ]
       }
     ]
@@ -97556,18 +96828,26 @@
       },
       {
         "item_id": 995,
-        "chance": 32,
+        "chance": 8,
         "amounts": [
-          1,
-          26
+          5,
+          5
         ]
       },
       {
-        "item_id": 1203,
-        "chance": 32,
+        "item_id": 2347,
+        "chance": 16,
         "amounts": [
           1,
           1
+        ]
+      },
+      {
+        "item_id": 995,
+        "chance": 32,
+        "amounts": [
+          9,
+          15
         ]
       },
       {
@@ -97579,35 +96859,11 @@
         ]
       },
       {
-        "item_id": 1139,
-        "chance": 32,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 1173,
         "chance": 32,
         "amounts": [
           1,
           1
-        ]
-      },
-      {
-        "item_id": 556,
-        "chance": 32,
-        "amounts": [
-          2,
-          4
-        ]
-      },
-      {
-        "item_id": 559,
-        "chance": 32,
-        "amounts": [
-          2,
-          11
         ]
       },
       {
@@ -97624,6 +96880,14 @@
         "amounts": [
           6,
           6
+        ]
+      },
+      {
+        "item_id": 559,
+        "chance": 32,
+        "amounts": [
+          7,
+          7
         ]
       },
       {
@@ -97651,7 +96915,7 @@
         ]
       },
       {
-        "item_id": 1155,
+        "item_id": 1237,
         "chance": 64,
         "amounts": [
           1,
@@ -97659,47 +96923,7 @@
         ]
       },
       {
-        "item_id": 1277,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1291,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 884,
-        "chance": 64,
-        "amounts": [
-          3,
-          6
-        ]
-      },
-      {
-        "item_id": 1103,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1381,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1189,
+        "item_id": 1917,
         "chance": 64,
         "amounts": [
           1,
@@ -97715,107 +96939,11 @@
         ]
       },
       {
-        "item_id": 1442,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
         "item_id": 558,
         "chance": 64,
         "amounts": [
           2,
           19
-        ]
-      },
-      {
-        "item_id": 1440,
-        "chance": 64,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1351,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1321,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1153,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1129,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1007,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 562,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 561,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 1448,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 946,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
-        ]
-      },
-      {
-        "item_id": 438,
-        "chance": 256,
-        "amounts": [
-          1,
-          1
         ]
       }
     ]
@@ -139001,7 +138129,15 @@
       },
       {
         "item_id": 6739,
-        "chance": 256,
+        "chance": 128,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 6733,
+        "chance": 128,
         "amounts": [
           1,
           1
@@ -139382,7 +138518,7 @@
       },
       {
         "item_id": 6739,
-        "chance": 256,
+        "chance": 128,
         "amounts": [
           1,
           1
@@ -139583,6 +138719,14 @@
       {
         "item_id": 5303,
         "chance": 256,
+        "amounts": [
+          1,
+          1
+        ]
+      },
+      {
+        "item_id": 6731,
+        "chance": 128,
         "amounts": [
           1,
           1

--- a/2006Scape Server/data/cfg/npcdrops.json
+++ b/2006Scape Server/data/cfg/npcdrops.json
@@ -6211,7 +6211,7 @@
       },
       {
         "item_id": 1351,
-        "chance": 64,
+        "chance": 16,
         "amounts": [
           1,
           1

--- a/2006Scape Server/data/cfg/spawns.json
+++ b/2006Scape Server/data/cfg/spawns.json
@@ -10970,9 +10970,9 @@
     "height": 2
   },
   {
-    "maxHit": 16,
+    "maxHit": 8,
     "strength": 150,
-    "attack": 250,
+    "attack": 135,
     "x": 3425,
     "y": 3568,
     "id": 1615,
@@ -10980,9 +10980,9 @@
     "height": 2
   },
   {
-    "maxHit": 16,
-    "strength": 150,
-    "attack": 250,
+    "maxHit": 8,
+    "strength": 67,
+    "attack": 135,
     "x": 3428,
     "y": 3565,
     "id": 1615,
@@ -10990,8 +10990,8 @@
     "height": 2
   },
   {
-    "maxHit": 16,
-    "strength": 150,
+    "maxHit": 8,
+    "strength": 67,
     "attack": 250,
     "x": 3425,
     "y": 3574,
@@ -11000,9 +11000,9 @@
     "height": 2
   },
   {
-    "maxHit": 16,
+    "maxHit": 8,
     "strength": 150,
-    "attack": 250,
+    "attack": 135,
     "x": 3423,
     "y": 3572,
     "id": 1615,
@@ -11010,9 +11010,9 @@
     "height": 2
   },
   {
-    "maxHit": 16,
-    "strength": 150,
-    "attack": 250,
+    "maxHit": 8,
+    "strength": 67,
+    "attack": 135,
     "x": 3427,
     "y": 3570,
     "id": 1615,
@@ -11020,9 +11020,9 @@
     "height": 2
   },
   {
-    "maxHit": 16,
-    "strength": 150,
-    "attack": 250,
+    "maxHit": 8,
+    "strength": 67,
+    "attack": 135,
     "x": 3416,
     "y": 3567,
     "id": 1615,
@@ -11030,9 +11030,9 @@
     "height": 2
   },
   {
-    "maxHit": 16,
-    "strength": 150,
-    "attack": 250,
+    "maxHit": 8,
+    "strength": 67,
+    "attack": 135,
     "x": 3413,
     "y": 3570,
     "id": 1615,
@@ -11040,9 +11040,9 @@
     "height": 2
   },
   {
-    "maxHit": 16,
-    "strength": 150,
-    "attack": 250,
+    "maxHit": 8,
+    "strength": 67,
+    "attack": 135,
     "x": 3410,
     "y": 3574,
     "id": 1615,
@@ -11050,9 +11050,9 @@
     "height": 2
   },
   {
-    "maxHit": 16,
-    "strength": 150,
-    "attack": 250,
+    "maxHit": 8,
+    "strength": 67,
+    "attack": 135,
     "x": 3413,
     "y": 3574,
     "id": 1615,

--- a/2006Scape Server/data/cfg/spawns.json
+++ b/2006Scape Server/data/cfg/spawns.json
@@ -7760,9 +7760,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3223,
     "y": 3208,
     "id": 1,
@@ -7770,9 +7770,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3221,
     "y": 3223,
     "id": 3,
@@ -7780,9 +7780,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3231,
     "y": 3207,
     "id": 2,
@@ -7790,9 +7790,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3231,
     "y": 3207,
     "id": 3,
@@ -7800,9 +7800,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3226,
     "y": 3261,
     "id": 1770,
@@ -7810,9 +7810,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3227,
     "y": 3264,
     "id": 1770,
@@ -7820,9 +7820,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3229,
     "y": 3264,
     "id": 1770,
@@ -7830,9 +7830,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3242,
     "y": 3265,
     "id": 1771,
@@ -7840,9 +7840,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3248,
     "y": 3261,
     "id": 1771,
@@ -7850,9 +7850,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3248,
     "y": 3261,
     "id": 1771,
@@ -7860,9 +7860,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3255,
     "y": 3252,
     "id": 1772,
@@ -7870,9 +7870,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3260,
     "y": 3249,
     "id": 1772,
@@ -7880,9 +7880,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3261,
     "y": 3243,
     "id": 1772,
@@ -7890,9 +7890,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3262,
     "y": 3230,
     "id": 1773,
@@ -7900,9 +7900,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3262,
     "y": 3220,
     "id": 1773,
@@ -7910,9 +7910,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3263,
     "y": 3215,
     "id": 1773,
@@ -7920,9 +7920,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3255,
     "y": 3223,
     "id": 1774,
@@ -7930,9 +7930,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3252,
     "y": 3226,
     "id": 1774,
@@ -7940,9 +7940,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3253,
     "y": 3229,
     "id": 1774,
@@ -7950,9 +7950,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3251,
     "y": 3235,
     "id": 1775,
@@ -7960,9 +7960,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3246,
     "y": 3235,
     "id": 1775,
@@ -7970,9 +7970,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3247,
     "y": 3237,
     "id": 1775,
@@ -7980,9 +7980,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3247,
     "y": 3241,
     "id": 1776,
@@ -7990,9 +7990,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3244,
     "y": 3257,
     "id": 1776,
@@ -8000,9 +8000,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3226,
     "y": 3270,
     "id": 1776,
@@ -8010,9 +8010,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3254,
     "y": 3256,
     "id": 1767,
@@ -8580,9 +8580,9 @@
     "height": 0
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3285,
     "y": 3172,
     "id": 18,
@@ -8590,9 +8590,9 @@
     "height": 0
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3288,
     "y": 3169,
     "id": 18,
@@ -8600,9 +8600,9 @@
     "height": 0
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3295,
     "y": 3170,
     "id": 18,
@@ -8610,9 +8610,9 @@
     "height": 0
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3297,
     "y": 3175,
     "id": 18,
@@ -8620,9 +8620,9 @@
     "height": 0
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3300,
     "y": 3171,
     "id": 18,
@@ -8630,9 +8630,9 @@
     "height": 0
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3302,
     "y": 3167,
     "id": 18,
@@ -8640,9 +8640,9 @@
     "height": 0
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3301,
     "y": 3164,
     "id": 18,
@@ -8650,9 +8650,9 @@
     "height": 0
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3295,
     "y": 3161,
     "id": 18,
@@ -8660,9 +8660,9 @@
     "height": 0
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3290,
     "y": 3161,
     "id": 18,
@@ -8680,9 +8680,9 @@
     "height": 0
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3283,
     "y": 3161,
     "id": 18,
@@ -8690,9 +8690,9 @@
     "height": 0
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3286,
     "y": 3163,
     "id": 18,
@@ -8700,9 +8700,9 @@
     "height": 1
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3287,
     "y": 3168,
     "id": 18,
@@ -8710,9 +8710,9 @@
     "height": 1
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3285,
     "y": 3174,
     "id": 18,
@@ -8720,9 +8720,9 @@
     "height": 1
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3298,
     "y": 3164,
     "id": 18,
@@ -8730,9 +8730,9 @@
     "height": 1
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3294,
     "y": 3162,
     "id": 18,
@@ -8740,9 +8740,9 @@
     "height": 1
   },
   {
-    "maxHit": 3,
+    "maxHit": 2,
     "strength": 20,
-    "attack": 20,
+    "attack": 24,
     "x": 3287,
     "y": 3160,
     "id": 18,
@@ -9790,9 +9790,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3097,
     "y": 3509,
     "id": 2,
@@ -9800,9 +9800,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3093,
     "y": 3512,
     "id": 3,
@@ -9810,9 +9810,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3092,
     "y": 3508,
     "id": 1,
@@ -10971,7 +10971,7 @@
   },
   {
     "maxHit": 8,
-    "strength": 150,
+    "strength": 67,
     "attack": 135,
     "x": 3425,
     "y": 3568,
@@ -10992,7 +10992,7 @@
   {
     "maxHit": 8,
     "strength": 67,
-    "attack": 250,
+    "attack": 135,
     "x": 3425,
     "y": 3574,
     "id": 1615,
@@ -11001,7 +11001,7 @@
   },
   {
     "maxHit": 8,
-    "strength": 150,
+    "strength": 67,
     "attack": 135,
     "x": 3423,
     "y": 3572,
@@ -14200,9 +14200,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 2595,
     "y": 3105,
     "id": 3,
@@ -14210,9 +14210,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 2601,
     "y": 3103,
     "id": 1,
@@ -20640,9 +20640,9 @@
     "height": 1
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3280,
     "y": 3500,
     "id": 1,
@@ -20650,9 +20650,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3280,
     "y": 3496,
     "id": 4,
@@ -20660,9 +20660,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3280,
     "y": 3492,
     "id": 1,
@@ -20700,9 +20700,9 @@
     "height": 1
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3231,
     "y": 3238,
     "id": 4,
@@ -20710,9 +20710,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3230,
     "y": 3239,
     "id": 1,
@@ -20750,9 +20750,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3215,
     "y": 3241,
     "id": 1,
@@ -20760,9 +20760,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3243,
     "y": 3213,
     "id": 4,
@@ -21010,9 +21010,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 2691,
     "y": 3495,
     "id": 4,
@@ -21020,9 +21020,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 2691,
     "y": 3495,
     "id": 4,
@@ -21030,9 +21030,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 2697,
     "y": 3496,
     "id": 4,
@@ -21040,9 +21040,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 2694,
     "y": 3495,
     "id": 1,
@@ -21050,9 +21050,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 2695,
     "y": 3489,
     "id": 1,
@@ -21060,9 +21060,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 2695,
     "y": 3492,
     "id": 1,
@@ -21110,9 +21110,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 10,
-    "attack": 10,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 2573,
     "y": 3320,
     "id": 4,
@@ -21960,9 +21960,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3492,
     "y": 3492,
     "id": 1,
@@ -21970,9 +21970,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3487,
     "y": 3486,
     "id": 1,
@@ -21980,9 +21980,9 @@
     "height": 0
   },
   {
-    "maxHit": 2,
-    "strength": 5,
-    "attack": 5,
+    "maxHit": 1,
+    "strength": 15,
+    "attack": 15,
     "x": 3498,
     "y": 3491,
     "id": 4,

--- a/2006Scape Server/src/main/java/com/rs2/game/content/combat/npcs/NpcEmotes.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/combat/npcs/NpcEmotes.java
@@ -11,6 +11,7 @@ import com.rs2.game.players.Player;
 
 public enum NpcEmotes {
 		MAN(new int[] {1, 2, 3, 4, 5, 6}, 422, 1834, 836),
+		AL_KHARID_WARRIOR(new int[] {18}, 451, 404, 836),
 		GUARD(new int[] {9, 10}, 412, 404, 836),
 		GARGOYLE(new int[] {1610, 1611}, 1517, 1519, 1518),
 		SKELETAL_WYVERN(new int[] {3068}, 2989, 2988, 2987),

--- a/2006Scape Server/src/main/java/com/rs2/game/content/skills/cooking/Cooking.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/skills/cooking/Cooking.java
@@ -37,9 +37,10 @@ public class Cooking extends SkillHandler {
 				KARAMBWAN(3142, 3144, 3146, 1, 80, 20, 20, "karambwan"), 
 				LOBSTER(377, 379, 381, 40, 120, 74, 68, "lobster"), 
 				SWORDFISH(371, 373, 375, 50, 140, 86, 81, "swordfish"),
-				MONKFISH(7944, 7946, 7948, 62, 150, 92, 90,	"monkfish"), 
-				SHARK(383, 385, 387, 76, 210, 100, 94, "shark"), 
-				MANTA_RAY(389, 391, 393, 91, 169, 100, 100, "manta ray"),
+				MONKFISH(7944, 7946, 7948, 62, 150, 92, 90,	"monkfish"),
+				SHARK(383, 385, 387, 76, 210, 100, 94, "shark"),
+				SEA_TURTLE(395, 397, 399, 82, 211, 100, 97, "sea turtle"),
+				MANTA_RAY(389, 391, 393, 91, 216, 100, 100, "manta ray"),
 				SEAWEED(401, 1781, 1781, 1, 1, 1, 1, "sea weed"),
 				CURRY(2009, 2011, 2013, 60, 280, 74, 74, "curry");
 

--- a/2006Scape Server/src/main/java/com/rs2/game/npcs/NpcHandler.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/npcs/NpcHandler.java
@@ -540,7 +540,7 @@ public class NpcHandler {
 				    else
 					    npcs[i].forceChat("Don't stay silent - victory in numbers!!");
 			    }
-		    }    
+		    }
                 if (npcs[i].spawnedBy > 0) {
                     if (PlayerHandler.players[npcs[i].spawnedBy] == null
                             || PlayerHandler.players[npcs[i].spawnedBy].heightLevel != npcs[i].heightLevel
@@ -1049,10 +1049,14 @@ public class NpcHandler {
                 // These npcs shouldn't have drops
                 return;
             }
+            boolean isDropped = false;
             for (ItemDrop possible_drop : NPCDropsHandler.getNpcDrops(getNpcListName(npcs[i].npcType).toLowerCase().replace(" ", "_"), npcs[i].npcType)) {
-                if (Misc.random(possible_drop.getChance()) == 0) {
+                if (Misc.random(possible_drop.getChance()) == 0 && !isDropped) {
                     int amt = possible_drop.getAmount();
                     GameEngine.itemHandler.createGroundItem(c, possible_drop.getItemID(), npcs[i].absX, npcs[i].absY, amt, c.playerId);
+                    //Making sure items that always drop don't cost us our drop table roll
+                    if (possible_drop.getChance() > 1)
+                        isDropped = true;
                 }
             }
             switch (npcs[i].npcType) {

--- a/2006Scape Server/src/main/java/com/rs2/net/packets/impl/ClickObject.java
+++ b/2006Scape Server/src/main/java/com/rs2/net/packets/impl/ClickObject.java
@@ -154,7 +154,7 @@ public class ClickObject implements PacketType {
 				if (player.spiritTree == false && player.clickedTree == false) {
 					player.getPacketSender().sendMessage("You attempt to chop the tree, and a tree spirit appears !");
 					player.getPacketSender().sendSound(300, 100, 1);
-					NpcHandler.spawnNpc(player, 655, player.getX(), player.getY(), 0, 0, 225, 20, 80, 80, true, true);
+					NpcHandler.spawnNpc(player, 655, player.getX(), player.getY(), 0, 0, 90, 9, 70, 70, true, true);
 					player.clickedTree = true;
 				} else if (player.spiritTree && player.lostCity >= 2) {
 					Woodcutting.startWoodcutting(player, player.objectId, player.objectX, player.objectY, player.clickObjectType);

--- a/2006Scape Server/src/main/java/com/rs2/net/packets/impl/ClickObject.java
+++ b/2006Scape Server/src/main/java/com/rs2/net/packets/impl/ClickObject.java
@@ -154,7 +154,7 @@ public class ClickObject implements PacketType {
 				if (player.spiritTree == false && player.clickedTree == false) {
 					player.getPacketSender().sendMessage("You attempt to chop the tree, and a tree spirit appears !");
 					player.getPacketSender().sendSound(300, 100, 1);
-					NpcHandler.spawnNpc(player, 655, player.getX(), player.getY(), 0, 0, 90, 9, 70, 70, true, true);
+					NpcHandler.spawnNpc(player, 655, player.getX(), player.getY(), 0, 0, 85, 10, 70, 80, true, true);
 					player.clickedTree = true;
 				} else if (player.spiritTree && player.lostCity >= 2) {
 					Woodcutting.startWoodcutting(player, player.objectId, player.objectX, player.objectY, player.clickObjectType);


### PR DESCRIPTION
Tree spirit during lost city has been nerfed and will no longer constantly hit 20's on you.

Chance of getting bronze axe increased when killing zombies in entrana.

Fixed issue with cooking Sea Turtles, also fixed experience received when cooking Manta Rays.

Drop table fixed for goblins

Drop table fixed for Dagannoth Supreme and Dagannoth Prime

Drop table no longer rolls multiple times, it will only roll once, unless npc has a 100% drop item, in that case it will roll the drop item and then roll once. (Might need to look at this depending on other monsters which could require multiple drops).

Fixed Al Kharid Warrior emote

Nerfed Abyssal Demon max hit (from 16 to 8)

Adjusted stats for Man, Woman, Goblin and Al Kharid Warrior NPCs.