### PR TITLE
Fixed client frame offsets/padding

### DIFF
--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -4813,9 +4813,6 @@ public class Game extends RSApplet {
 	Component getGameComponent() {
 		if (Signlink.mainapp != null) {
 			return Signlink.mainapp;
-		}
-		if (super.gameFrame != null) {
-			return super.gameFrame;
 		} else {
 			return this;
 		}

--- a/2006Scape Client/src/main/java/RSApplet.java
+++ b/2006Scape Client/src/main/java/RSApplet.java
@@ -2,7 +2,6 @@
 // Jad home page: http://www.kpdus.com/jad.html
 // Decompiler options: packimports(3) 
 
-import javax.swing.*;
 import java.applet.Applet;
 import java.awt.*;
 import java.awt.event.FocusEvent;
@@ -29,7 +28,9 @@ public class RSApplet extends Applet implements Runnable, MouseListener, MouseWh
 	final void createClientFrame(int i, int j) {
 		myWidth = j;
 		myHeight = i;
-		gameFrame = new RSFrame(this, myWidth, myHeight);
+		this.setPreferredSize(new Dimension(this.myWidth, this.myHeight));
+
+		gameFrame = new RSFrame(this);
 		graphics = getGameComponent().getGraphics();
 		fullGameScreen = new RSImageProducer(myWidth, myHeight, getGameComponent());
 		startRunnable(this, 1);
@@ -215,10 +216,6 @@ public class RSApplet extends Applet implements Runnable, MouseListener, MouseWh
 	public final void mousePressed(MouseEvent mouseevent) {
 		int i = mouseevent.getX();
 		int j = mouseevent.getY();
-		if (gameFrame != null) {
-			i -= 4;
-			j -= 22;
-		}
 		idleTime = 0;
 		clickX = i;
 		clickY = j;
@@ -265,11 +262,6 @@ public class RSApplet extends Applet implements Runnable, MouseListener, MouseWh
 	public final void mouseDragged(MouseEvent e) {
 		int x = e.getX();
 		int y = e.getY();
-		if(gameFrame != null) {
-			Insets insets = gameFrame.getInsets();
-			x -= insets.left;//4
-			y -= insets.top;//22
-		}
 		if (mouseWheelDown) {
 			y = mouseWheelX - e.getX();
 			int k = mouseWheelY - e.getY();
@@ -290,10 +282,6 @@ public class RSApplet extends Applet implements Runnable, MouseListener, MouseWh
 	public void mouseMoved(MouseEvent mouseevent) {
 		int i = mouseevent.getX();
 		int j = mouseevent.getY();
-		if (gameFrame != null) {
-			i -= 4;
-			j -= 22;
-		}
 		idleTime = 0;
 		mouseX = i;
 		mouseY = j;
@@ -498,11 +486,7 @@ public class RSApplet extends Applet implements Runnable, MouseListener, MouseWh
 	}
 
 	Component getGameComponent() {
-		if (gameFrame != null) {
-			return gameFrame;
-		} else {
-			return this;
-		}
+		return this;
 	}
 
 	public void startRunnable(Runnable runnable, int priority) {

--- a/2006Scape Client/src/main/java/RSFrame.java
+++ b/2006Scape Client/src/main/java/RSFrame.java
@@ -6,22 +6,18 @@ import java.awt.*;
 
 final class RSFrame extends Frame {
 
-	public RSFrame(RSApplet RSApplet_, int i, int j) {
+	public RSFrame(RSApplet RSApplet_) {
 		rsApplet = RSApplet_;
 		setTitle(ClientSettings.SERVER_NAME + " World: " + ClientSettings.SERVER_WORLD);
-		setResizable(false);
-		setMinimumSize(new Dimension(i + 8, j + 28));
-		setVisible(true);
-		toFront();
-		setSize(i + 8, j + 28);
-		setLocationRelativeTo(null);
-	}
+		this.setResizable(false);
 
-	@Override
-	public Graphics getGraphics() {
-		Graphics g = super.getGraphics();
-		g.translate(4, 24);
-		return g;
+		this.setLayout(new BorderLayout());
+		this.add(rsApplet);
+		this.pack();
+
+		this.setVisible(true);
+		this.toFront();
+		this.setLocationRelativeTo(null);
 	}
 
 	@Override


### PR DESCRIPTION
The frame is no longer cut off at the top and other OSes (Linux) won't have extra padding around the edge.

Looks like this now:  
<img width="575" alt="image" src="https://user-images.githubusercontent.com/5841704/215286725-27715130-0c85-4270-9484-8e6382558ebb.png">
