### PR TITLE
3 configurable graphics fixes in ClientSettings

### DIFF
--- a/2006Scape Client/src/main/java/ClientSettings.java
+++ b/2006Scape Client/src/main/java/ClientSettings.java
@@ -54,4 +54,15 @@ public class ClientSettings {
 	
 	public static final BigInteger RSA_MODULUS = new BigInteger("91553247461173033466542043374346300088148707506479543786501537350363031301992107112953015516557748875487935404852620239974482067336878286174236183516364787082711186740254168914127361643305190640280157664988536979163450791820893999053469529344247707567448479470137716627440246788713008490213212272520901741443");
 	public static final BigInteger RSA_EXPONENT = new BigInteger("65537");
+
+	// smooths out lines and sprites on the minimap
+	public static final boolean BILINEAR_MINIMAP_FILTERING = false;
+
+	// fixes overlapping lines drawn on transparent objects by post-incrementing the offset
+	// note: there's 2 other instances that haven't been updated in Texture.java (misnamed) because rarely used like this
+	public static final boolean FIX_TRANSPARENCY_OVERFLOW = false;
+
+	// render the game to 512px instead of 511px (black line on right side)
+	public static final boolean FULL_512PX_VIEWPORT = false;
+
 }

--- a/2006Scape Client/src/main/java/DrawingArea.java
+++ b/2006Scape Client/src/main/java/DrawingArea.java
@@ -16,7 +16,11 @@ public class DrawingArea extends NodeSub {
 		topY = 0;
 		bottomX = width;
 		bottomY = height;
-		centerX = bottomX - 1;
+		if (ClientSettings.FULL_512PX_VIEWPORT) {
+			centerX = bottomX;
+		} else {
+			centerX = bottomX - 1;
+		}
 		centerY = bottomX / 2;
 	}
 
@@ -37,7 +41,11 @@ public class DrawingArea extends NodeSub {
 		topY = l;
 		bottomX = k;
 		bottomY = i;
-		centerX = bottomX - 1;
+		if (ClientSettings.FULL_512PX_VIEWPORT) {
+			centerX = bottomX;
+		} else {
+			centerX = bottomX - 1;
+		}
 		centerY = bottomX / 2;
 		anInt1387 = bottomY / 2;
 	}

--- a/2006Scape Client/src/main/java/Sprite.java
+++ b/2006Scape Client/src/main/java/Sprite.java
@@ -366,7 +366,30 @@ public final class Sprite extends DrawingArea {
 				int k4 = j3 + i3 * i4;
 				int l4 = k3 - l2 * i4;
 				for (k1 = -ai[j1]; k1 < 0; k1++) {
-					DrawingArea.pixels[j4++] = pixels[(k4 >> 16) + (l4 >> 16) * width];
+					if (ClientSettings.BILINEAR_MINIMAP_FILTERING) {
+						int x1 = k4 >> 16;
+						int y1 = l4 >> 16;
+						int x2 = x1 + 1;
+						int y2 = y1 + 1;
+						int sampleColor1 = pixels[x1 + y1 * width];
+						int sampleColor2 = pixels[x2 + y1 * width];
+						int sampleColor3 = pixels[x1 + y2 * width];
+						int sampleColor4 = pixels[x2 + y2 * width];
+						int x1Distance = (k4 >> 8) - (x1 << 8);
+						int y1Distance = (l4 >> 8) - (y1 << 8);
+						int x2Distance = (x2 << 8) - (k4 >> 8);
+						int y2Distance = (y2 << 8) - (l4 >> 8);
+						int sampleAlpha1 = x2Distance * y2Distance;
+						int sampleAlpha2 = x1Distance * y2Distance;
+						int sampleAlpha3 = x2Distance * y1Distance;
+						int sampleAlpha4 = x1Distance * y1Distance;
+						int red = (sampleColor1 >> 16 & 0xff) * sampleAlpha1 + (sampleColor2 >> 16 & 0xff) * sampleAlpha2 + (sampleColor3 >> 16 & 0xff) * sampleAlpha3 + (sampleColor4 >> 16 & 0xff) * sampleAlpha4 & 0xff0000;
+						int green = (sampleColor1 >> 8 & 0xff) * sampleAlpha1 + (sampleColor2 >> 8 & 0xff) * sampleAlpha2 + (sampleColor3 >> 8 & 0xff) * sampleAlpha3 + (sampleColor4 >> 8 & 0xff) * sampleAlpha4 >> 8 & 0xff00;
+						int blue = (sampleColor1 & 0xff) * sampleAlpha1 + (sampleColor2 & 0xff) * sampleAlpha2 + (sampleColor3 & 0xff) * sampleAlpha3 + (sampleColor4 & 0xff) * sampleAlpha4 >> 16;
+						DrawingArea.pixels[j4++] = red | green | blue;
+					} else {
+						DrawingArea.pixels[j4++] = pixels[(k4 >> 16) + (l4 >> 16) * width];
+					}
 					k4 += i3;
 					l4 -= l2;
 				}

--- a/2006Scape Client/src/main/java/Texture.java
+++ b/2006Scape Client/src/main/java/Texture.java
@@ -730,22 +730,47 @@ final class Texture extends DrawingArea {
 			} else {
 				int j2 = anInt1465;
 				int l2 = 256 - anInt1465;
-				while (--k >= 0) {
-					j = anIntArray1482[j1 >> 8];
-					j1 += l1;
-					j = ((j & 0xff00ff) * l2 >> 8 & 0xff00ff) + ((j & 0xff00) * l2 >> 8 & 0xff00);
-					ai[i++] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
-					ai[i++] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
-					ai[i++] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
-					ai[i++] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
-				}
-				k = i1 - l & 3;
-				if (k > 0) {
-					j = anIntArray1482[j1 >> 8];
-					j = ((j & 0xff00ff) * l2 >> 8 & 0xff00ff) + ((j & 0xff00) * l2 >> 8 & 0xff00);
-					do {
+				if (ClientSettings.FIX_TRANSPARENCY_OVERFLOW) {
+					while (--k >= 0) {
+						j = anIntArray1482[j1 >> 8];
+						j1 += l1;
+						j = ((j & 0xff00ff) * l2 >> 8 & 0xff00ff) + ((j & 0xff00) * l2 >> 8 & 0xff00);
+						ai[i] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
+						i++;
+						ai[i] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
+						i++;
+						ai[i] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
+						i++;
+						ai[i] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
+						i++;
+					}
+					k = i1 - l & 3;
+					if (k > 0) {
+						j = anIntArray1482[j1 >> 8];
+						j = ((j & 0xff00ff) * l2 >> 8 & 0xff00ff) + ((j & 0xff00) * l2 >> 8 & 0xff00);
+						do {
+							ai[i] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
+							i++;
+						} while (--k > 0);
+					}
+				} else {
+					while (--k >= 0) {
+						j = anIntArray1482[j1 >> 8];
+						j1 += l1;
+						j = ((j & 0xff00ff) * l2 >> 8 & 0xff00ff) + ((j & 0xff00) * l2 >> 8 & 0xff00);
 						ai[i++] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
-					} while (--k > 0);
+						ai[i++] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
+						ai[i++] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
+						ai[i++] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
+					}
+					k = i1 - l & 3;
+					if (k > 0) {
+						j = anIntArray1482[j1 >> 8];
+						j = ((j & 0xff00ff) * l2 >> 8 & 0xff00ff) + ((j & 0xff00) * l2 >> 8 & 0xff00);
+						do {
+							ai[i++] = j + ((ai[i] & 0xff00ff) * j2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j2 >> 8 & 0xff00);
+						} while (--k > 0);
+					}
 				}
 			}
 			return;
@@ -777,12 +802,22 @@ final class Texture extends DrawingArea {
 		}
 		int k2 = anInt1465;
 		int i3 = 256 - anInt1465;
-		do {
-			j = anIntArray1482[j1 >> 8];
-			j1 += i2;
-			j = ((j & 0xff00ff) * i3 >> 8 & 0xff00ff) + ((j & 0xff00) * i3 >> 8 & 0xff00);
-			ai[i++] = j + ((ai[i] & 0xff00ff) * k2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * k2 >> 8 & 0xff00);
-		} while (--k > 0);
+		if (ClientSettings.FIX_TRANSPARENCY_OVERFLOW) {
+			do {
+				j = anIntArray1482[j1 >> 8];
+				j1 += i2;
+				j = ((j & 0xff00ff) * i3 >> 8 & 0xff00ff) + ((j & 0xff00) * i3 >> 8 & 0xff00);
+				ai[i] = j + ((ai[i] & 0xff00ff) * k2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * k2 >> 8 & 0xff00);
+				i++;
+			} while (--k > 0);
+		} else {
+			do {
+				j = anIntArray1482[j1 >> 8];
+				j1 += i2;
+				j = ((j & 0xff00ff) * i3 >> 8 & 0xff00ff) + ((j & 0xff00) * i3 >> 8 & 0xff00);
+				ai[i++] = j + ((ai[i] & 0xff00ff) * k2 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * k2 >> 8 & 0xff00);
+			} while (--k > 0);
+		}
 	}
 
 	public static void method376(int i, int j, int k, int l, int i1, int j1, int k1) {
@@ -1125,16 +1160,32 @@ final class Texture extends DrawingArea {
 		int j1 = anInt1465;
 		int k1 = 256 - anInt1465;
 		j = ((j & 0xff00ff) * k1 >> 8 & 0xff00ff) + ((j & 0xff00) * k1 >> 8 & 0xff00);
-		while (--k >= 0) {
-			ai[i++] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
-			ai[i++] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
-			ai[i++] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
-			ai[i++] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
+		if (ClientSettings.FIX_TRANSPARENCY_OVERFLOW) {
+			while (--k >= 0) {
+				ai[i] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
+				i++;
+				ai[i] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
+				i++;
+				ai[i] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
+				i++;
+				ai[i] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
+				i++;
+			}
+			for (k = i1 - l & 3; --k >= 0;) {
+				ai[i] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
+				i++;
+			}
+		} else {
+			while (--k >= 0) {
+				ai[i++] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
+				ai[i++] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
+				ai[i++] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
+				ai[i++] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
+			}
+			for (k = i1 - l & 3; --k >= 0;) {
+				ai[i++] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
+			}
 		}
-		for (k = i1 - l & 3; --k >= 0;) {
-			ai[i++] = j + ((ai[i] & 0xff00ff) * j1 >> 8 & 0xff00ff) + ((ai[i] & 0xff00) * j1 >> 8 & 0xff00);
-		}
-
 	}
 
 	public static void method378(int i, int j, int k, int l, int i1, int j1, int k1, int l1, int i2, int j2, int k2, int l2, int i3, int j3, int k3, int l3, int i4, int j4, int k4) {


### PR DESCRIPTION
3 new options:
1) bilinear minimap filtering, smooths out jagged edges on the minimap and compass
2) transparency overflow fix, triangles could have lines drawn at their seams at most camera angles
3) full 512px viewport, the client has a "safe rendering size" that it used but resulted in 511px being drawn instead of 512, despite the area being 512. So you were left with a black border on the right side

Before vs After:
![image](https://user-images.githubusercontent.com/5841704/215287997-51db946b-9880-4385-9585-1f341ad73f15.png)
![image](https://user-images.githubusercontent.com/5841704/215288001-c0b77830-ad6a-427c-b747-72c88ba51bfe.png)
