### PR TITLE
Fix getLevelforXP methods

### DIFF
--- a/2006Scape Server/src/main/java/com/rs2/game/content/combat/CombatAssistant.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/combat/CombatAssistant.java
@@ -320,8 +320,8 @@ public class CombatAssistant {
 		}
 		if (damage > 0 && guthansEffect) {
 			player.playerLevel[GameConstants.HITPOINTS] += damage;
-			if (player.playerLevel[GameConstants.HITPOINTS] > player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
-				player.playerLevel[GameConstants.HITPOINTS] = player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS]);
+			if (player.playerLevel[GameConstants.HITPOINTS] > player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
+				player.playerLevel[GameConstants.HITPOINTS] = player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS]);
 			}
 			player.getPlayerAssistant().refreshSkill(GameConstants.HITPOINTS);
 			NpcHandler.npcs[i].gfx0(398);
@@ -332,10 +332,10 @@ public class CombatAssistant {
 		switch (player.specEffect) {
 		case 4:
 			if (damage > 0) {
-				if (player.playerLevel[GameConstants.HITPOINTS] + damage > player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
-					if (player.playerLevel[GameConstants.HITPOINTS] > player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
+				if (player.playerLevel[GameConstants.HITPOINTS] + damage > player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
+					if (player.playerLevel[GameConstants.HITPOINTS] > player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
 					} else {
-						player.playerLevel[GameConstants.HITPOINTS] = player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS]);
+						player.playerLevel[GameConstants.HITPOINTS] = player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS]);
 					}
 				} else {
 					player.playerLevel[GameConstants.HITPOINTS] += damage;
@@ -1435,8 +1435,8 @@ public class CombatAssistant {
 		}
 		if (damage > 0 && guthansEffect) {
 			player.playerLevel[GameConstants.HITPOINTS] += damage;
-			if (player.playerLevel[GameConstants.HITPOINTS] > player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
-				player.playerLevel[GameConstants.HITPOINTS] = player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS]);
+			if (player.playerLevel[GameConstants.HITPOINTS] > player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
+				player.playerLevel[GameConstants.HITPOINTS] = player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS]);
 			}
 			player.getPlayerAssistant().refreshSkill(GameConstants.HITPOINTS);
 			o.gfx0(398);
@@ -1488,9 +1488,9 @@ public class CombatAssistant {
 			break;
 		case 4:
 			if (damage > 0) {
-				if (player.playerLevel[GameConstants.HITPOINTS] + damage > player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
-					if (player.playerLevel[GameConstants.HITPOINTS] < player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
-						player.playerLevel[GameConstants.HITPOINTS] = player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS]);
+				if (player.playerLevel[GameConstants.HITPOINTS] + damage > player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
+					if (player.playerLevel[GameConstants.HITPOINTS] < player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
+						player.playerLevel[GameConstants.HITPOINTS] = player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS]);
 					}
 				} else {
 					player.playerLevel[GameConstants.HITPOINTS] += damage;

--- a/2006Scape Server/src/main/java/com/rs2/game/content/combat/Specials.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/combat/Specials.java
@@ -278,7 +278,7 @@ public class Specials {
 				player2.forcedChat("Raarrrrrgggggghhhhhhh!");
 				player2.startAnimation(1056);
 				player2.specAmount -= 5;
-				player2.playerLevel[GameConstants.STRENGTH] = player2.getLevelForXP(player2.playerXP[GameConstants.STRENGTH]) + player2.getLevelForXP(player2.playerXP[GameConstants.STRENGTH]) * 15 / 100;
+				player2.playerLevel[GameConstants.STRENGTH] = player2.getPlayerAssistant().getLevelForXP(player2.playerXP[GameConstants.STRENGTH]) + player2.getPlayerAssistant().getLevelForXP(player2.playerXP[GameConstants.STRENGTH]) * 15 / 100;
 				player2.getPlayerAssistant().refreshSkill(GameConstants.STRENGTH);
 				player2.getItemAssistant().updateSpecialBar();
 			} else {

--- a/2006Scape Server/src/main/java/com/rs2/game/content/combat/magic/MagicMaxHit.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/combat/magic/MagicMaxHit.java
@@ -8,7 +8,7 @@ public class MagicMaxHit {
 	public static int mageAttackBonus(Player c) {
 		int magicBonus = c.playerLevel[GameConstants.MAGIC];
 		if (MagicData.fullVoidMage(c)) {
-			magicBonus += c.getLevelForXP(c.playerXP[GameConstants.MAGIC]) * 0.2;
+			magicBonus += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.MAGIC]) * 0.2;
 		}
 		if (c.getPrayer().prayerActive[4]) {
 			magicBonus *= 1.05;
@@ -23,15 +23,15 @@ public class MagicMaxHit {
 	public static int mageDefenceBonus(Player c) {
 		int defenceBonus = c.playerLevel[GameConstants.DEFENCE] / 2 + c.playerLevel[GameConstants.MAGIC] / 2;
 		if (c.getPrayer().prayerActive[0]) {
-			defenceBonus += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.05;
+			defenceBonus += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.05;
 		} else if (c.getPrayer().prayerActive[3]) {
-			defenceBonus += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.1;
+			defenceBonus += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.1;
 		} else if (c.getPrayer().prayerActive[9]) {
-			defenceBonus += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.15;
+			defenceBonus += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.15;
 		} else if (c.getPrayer().prayerActive[18]) {
-			defenceBonus += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.2;
+			defenceBonus += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.2;
 		} else if (c.getPrayer().prayerActive[19]) {
-			defenceBonus += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.25;
+			defenceBonus += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.25;
 		}
 		return defenceBonus + c.playerBonus[8] + c.playerBonus[8] / 3;
 	}

--- a/2006Scape Server/src/main/java/com/rs2/game/content/combat/magic/MagicSpells.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/combat/magic/MagicSpells.java
@@ -63,7 +63,7 @@ public class MagicSpells extends MagicData {
 					- PlayerHandler.players[playerId].reduceStat > 35000) {
 				PlayerHandler.players[playerId].reduceStat = System
 						.currentTimeMillis();
-				PlayerHandler.players[playerId].playerLevel[GameConstants.ATTACK] -= PlayerHandler.players[playerId]
+				PlayerHandler.players[playerId].playerLevel[GameConstants.ATTACK] -= PlayerHandler.players[playerId].getPlayerAssistant()
 						.getLevelForXP(PlayerHandler.players[playerId].playerXP[GameConstants.ATTACK]) * 10 / 100;
 			}
 			break;

--- a/2006Scape Server/src/main/java/com/rs2/game/content/combat/melee/MeleeData.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/combat/melee/MeleeData.java
@@ -23,18 +23,18 @@ public class MeleeData {
         int attackLevel = c.playerLevel[GameConstants.ATTACK];
         // 2, 5, 11, 18, 19
         if (c.getPrayer().prayerActive[2]) {
-            attackLevel += c.getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.05;
+            attackLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.05;
         } else if (c.getPrayer().prayerActive[7]) {
-            attackLevel += c.getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.1;
+            attackLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.1;
         } else if (c.getPrayer().prayerActive[15]) {
-            attackLevel += c.getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.15;
+            attackLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.15;
         } else if (c.getPrayer().prayerActive[24]) {
-            attackLevel += c.getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.15;
+            attackLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.15;
         } else if (c.getPrayer().prayerActive[25]) {
-            attackLevel += c.getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.2;
+            attackLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.2;
         }
         if (fullVoidMelee(c)) {
-            attackLevel += c.getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.1;
+            attackLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 0.1;
         }
         attackLevel *= c.specAccuracy;
         // c.sendMessage("Attack: " + (attackLevel +
@@ -65,15 +65,15 @@ public class MeleeData {
         int defenceLevel = c.playerLevel[GameConstants.DEFENCE];
         int i = c.playerBonus[bestMeleeDef(c)];
         if (c.getPrayer().prayerActive[0]) {
-            defenceLevel += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.05;
+            defenceLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.05;
         } else if (c.getPrayer().prayerActive[5]) {
-            defenceLevel += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.1;
+            defenceLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.1;
         } else if (c.getPrayer().prayerActive[13]) {
-            defenceLevel += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.15;
+            defenceLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.15;
         } else if (c.getPrayer().prayerActive[24]) {
-            defenceLevel += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.2;
+            defenceLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.2;
         } else if (c.getPrayer().prayerActive[25]) {
-            defenceLevel += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.25;
+            defenceLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.25;
         }
         return (int) (defenceLevel + defenceLevel * 0.15 + (i + i * 0.05));
     }

--- a/2006Scape Server/src/main/java/com/rs2/game/content/combat/melee/MeleeMaxHit.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/combat/melee/MeleeMaxHit.java
@@ -9,7 +9,7 @@ public class MeleeMaxHit {
 		double maxHit = 0;
 		int strBonus = c.playerBonus[10];
 		int strength = c.playerLevel[GameConstants.STRENGTH];
-		int lvlForXP = c.getLevelForXP(c.playerXP[GameConstants.STRENGTH]);
+		int lvlForXP = c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.STRENGTH]);
 		if (c.getPrayer().prayerActive[1]) {
 			strength += (int) (lvlForXP * .05);
 		} else if (c.getPrayer().prayerActive[6]) {

--- a/2006Scape Server/src/main/java/com/rs2/game/content/combat/npcs/NpcCombat.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/combat/npcs/NpcCombat.java
@@ -657,7 +657,7 @@ public class NpcCombat {
 					c.getPlayerAssistant().handleROL();
 				} else {
 					int difference = c.playerLevel[GameConstants.HITPOINTS] - damage;
-					if (difference <= c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS]) / 10 && difference > 0) {
+					if (difference <= c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS]) / 10 && difference > 0) {
 						c.appendRedemption();
 					} 
 					if (c.playerLevel[GameConstants.HITPOINTS] - damage < 0) {

--- a/2006Scape Server/src/main/java/com/rs2/game/content/combat/range/RangeMaxHit.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/combat/range/RangeMaxHit.java
@@ -8,15 +8,15 @@ public class RangeMaxHit {
 	public static int calculateRangeDefence(Player c) {
 		int defenceLevel = c.playerLevel[GameConstants.DEFENCE];
 		if (c.getPrayer().prayerActive[0]) {
-			defenceLevel += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.05;
+			defenceLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.05;
 		} else if (c.getPrayer().prayerActive[5]) {
-			defenceLevel += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.1;
+			defenceLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.1;
 		} else if (c.getPrayer().prayerActive[13]) {
-			defenceLevel += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.15;
+			defenceLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.15;
 		} else if (c.getPrayer().prayerActive[24]) {
-			defenceLevel += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.2;
+			defenceLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.2;
 		} else if (c.getPrayer().prayerActive[25]) {
-			defenceLevel += c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.25;
+			defenceLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 0.25;
 		}
 		return defenceLevel + c.playerBonus[9] + c.playerBonus[9] / 2;
 	}
@@ -25,7 +25,7 @@ public class RangeMaxHit {
 		int rangeLevel = c.playerLevel[GameConstants.RANGED];
 		rangeLevel *= c.specAccuracy;
 		if (RangeData.fullVoidRange(c)) {
-			rangeLevel += c.getLevelForXP(c.playerXP[GameConstants.RANGED]) * 0.1;
+			rangeLevel += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.RANGED]) * 0.1;
 		}
 		if (c.getPrayer().prayerActive[3]) {
 			rangeLevel *= 1.05;

--- a/2006Scape Server/src/main/java/com/rs2/game/content/consumables/Beverages.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/consumables/Beverages.java
@@ -129,8 +129,8 @@ public class Beverages {
 		switch (id) {
 		case 1917:
 		case 7740://beer
-			double beerEffectStrength = c.getLevelForXP(c.playerXP[GameConstants.STRENGTH]) * .04 + c.getLevelForXP(c.playerXP[GameConstants.STRENGTH]);
-			double beerEffectAttack = c.getLevelForXP(c.playerXP[GameConstants.ATTACK]) * .07;
+			double beerEffectStrength = c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.STRENGTH]) * .04 + c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.STRENGTH]);
+			double beerEffectAttack = c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.ATTACK]) * .07;
 			if (c.playerLevel[GameConstants.STRENGTH] < beerEffectStrength) {
 				c.playerLevel[GameConstants.STRENGTH] = (int) beerEffectStrength;
 			}

--- a/2006Scape Server/src/main/java/com/rs2/game/content/consumables/Food.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/consumables/Food.java
@@ -256,11 +256,11 @@ public class Food {
 				player.getPacketSender().sendSound(SoundList.DRINK, 100, 0);
 			}
 			player.foodDelay = System.currentTimeMillis();
-			if (player.playerLevel[GameConstants.HITPOINTS] < player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
+			if (player.playerLevel[GameConstants.HITPOINTS] < player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
 				player.playerLevel[GameConstants.HITPOINTS] += f.getHeal();
 				player.getPacketSender().sendMessage("It heals some health.");
-				if (player.playerLevel[GameConstants.HITPOINTS] > player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
-					player.playerLevel[GameConstants.HITPOINTS] = player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS]);
+				if (player.playerLevel[GameConstants.HITPOINTS] > player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) {
+					player.playerLevel[GameConstants.HITPOINTS] = player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS]);
 				}
 			}
 			player.getPlayerAssistant().refreshSkill(GameConstants.HITPOINTS);

--- a/2006Scape Server/src/main/java/com/rs2/game/content/consumables/Kebabs.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/consumables/Kebabs.java
@@ -51,10 +51,10 @@ public class Kebabs {
 		} else if (Misc.random(100.0f) <= eff2) { // 61.24% heals 10% of HP
 			c.getPacketSender()
 					.sendMessage("It restores some life points.");
-			if (c.playerLevel[GameConstants.HITPOINTS] < c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
-				c.playerLevel[GameConstants.HITPOINTS] += c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS]) * 0.10;
-				if (c.playerLevel[GameConstants.HITPOINTS] > c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
-					c.playerLevel[GameConstants.HITPOINTS] = c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS]);
+			if (c.playerLevel[GameConstants.HITPOINTS] < c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
+				c.playerLevel[GameConstants.HITPOINTS] += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS]) * 0.10;
+				if (c.playerLevel[GameConstants.HITPOINTS] > c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
+					c.playerLevel[GameConstants.HITPOINTS] = c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS]);
 				}
 
 			}
@@ -62,10 +62,10 @@ public class Kebabs {
 		} else if (Misc.random(100.0f) <= eff3) { // 21.12% + 10-20 HP
 			c.getPacketSender().sendMessage(
 					"That was a good kebab. You feel a lot better. ");
-			if (c.playerLevel[GameConstants.HITPOINTS] < c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
+			if (c.playerLevel[GameConstants.HITPOINTS] < c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
 				c.playerLevel[GameConstants.HITPOINTS] += Misc.random(20);
-				if (c.playerLevel[GameConstants.HITPOINTS] > c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
-					c.playerLevel[GameConstants.HITPOINTS] = c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS]);
+				if (c.playerLevel[GameConstants.HITPOINTS] > c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
+					c.playerLevel[GameConstants.HITPOINTS] = c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS]);
 				}
 			}
 
@@ -80,10 +80,10 @@ public class Kebabs {
 			c.getPlayerAssistant().refreshSkill(GameConstants.DEFENCE);
 			c.getPlayerAssistant().refreshSkill(GameConstants.STRENGTH);
 			c.getPlayerAssistant().refreshSkill(GameConstants.HITPOINTS);
-			if (c.playerLevel[GameConstants.HITPOINTS] < c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
+			if (c.playerLevel[GameConstants.HITPOINTS] < c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
 				c.playerLevel[GameConstants.HITPOINTS] += Misc.random(30);
-				if (c.playerLevel[GameConstants.HITPOINTS] > c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
-					c.playerLevel[GameConstants.HITPOINTS] = c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS]);
+				if (c.playerLevel[GameConstants.HITPOINTS] > c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
+					c.playerLevel[GameConstants.HITPOINTS] = c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS]);
 				}
 			}
 
@@ -106,7 +106,7 @@ public class Kebabs {
 	public static void eat(Player player, int slot) {
 		if (System.currentTimeMillis() - player.foodDelay >= 1500
 				&& player.playerLevel[GameConstants.HITPOINTS] > 0) {
-			if (player.playerLevel[GameConstants.HITPOINTS] == player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) { // If
+			if (player.playerLevel[GameConstants.HITPOINTS] == player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS])) { // If
 																		// full
 																		// health,
 																		// does

--- a/2006Scape Server/src/main/java/com/rs2/game/content/consumables/Potions.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/consumables/Potions.java
@@ -330,12 +330,12 @@ public class Potions {
 		// c.startAnimation(829);
 		c.playerItems[slot] = replaceItem + 1;
 		c.getItemAssistant().resetItems(3214);
-		c.playerLevel[GameConstants.PRAYER] += c.getLevelForXP(c.playerXP[GameConstants.PRAYER]) * .33;
+		c.playerLevel[GameConstants.PRAYER] += c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.PRAYER]) * .33;
 		if (rest) {
 			c.playerLevel[GameConstants.PRAYER] += 1;
 		}
-		if (c.playerLevel[GameConstants.PRAYER] > c.getLevelForXP(c.playerXP[GameConstants.PRAYER])) {
-			c.playerLevel[GameConstants.PRAYER] = c.getLevelForXP(c.playerXP[GameConstants.PRAYER]);
+		if (c.playerLevel[GameConstants.PRAYER] > c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.PRAYER])) {
+			c.playerLevel[GameConstants.PRAYER] = c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.PRAYER]);
 		}
 		c.getPlayerAssistant().refreshSkill(GameConstants.PRAYER);
 		if (rest) {
@@ -348,10 +348,10 @@ public class Potions {
 			if (j == 5 || j == 3) {
 				continue;
 			}
-			if (c.playerLevel[j] < c.getLevelForXP(c.playerXP[j])) {
-				c.playerLevel[j] += c.getLevelForXP(c.playerXP[j]) * .33;
-				if (c.playerLevel[j] > c.getLevelForXP(c.playerXP[j])) {
-					c.playerLevel[j] = c.getLevelForXP(c.playerXP[j]);
+			if (c.playerLevel[j] < c.getPlayerAssistant().getLevelForXP(c.playerXP[j])) {
+				c.playerLevel[j] += c.getPlayerAssistant().getLevelForXP(c.playerXP[j]) * .33;
+				if (c.playerLevel[j] > c.getPlayerAssistant().getLevelForXP(c.playerXP[j])) {
+					c.playerLevel[j] = c.getPlayerAssistant().getLevelForXP(c.playerXP[j]);
 				}
 				c.getPlayerAssistant().refreshSkill(j);
 				c.getPacketSender().setSkillLevel(j, c.playerLevel[j],
@@ -375,16 +375,16 @@ public class Potions {
 					c.playerXP[tD]);
 		}
 		c.playerLevel[GameConstants.ATTACK] += getBrewStat(0, .20);
-		if (c.playerLevel[GameConstants.ATTACK] > c.getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 1.2 + 1) {
-			c.playerLevel[GameConstants.ATTACK] = (int) (c.getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 1.2);
+		if (c.playerLevel[GameConstants.ATTACK] > c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 1.2 + 1) {
+			c.playerLevel[GameConstants.ATTACK] = (int) (c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.ATTACK]) * 1.2);
 		}
 		c.playerLevel[GameConstants.STRENGTH] += getBrewStat(2, .12);
-		if (c.playerLevel[GameConstants.STRENGTH] > c.getLevelForXP(c.playerXP[GameConstants.STRENGTH]) * 1.2 + 1) {
-			c.playerLevel[GameConstants.STRENGTH] = (int) (c.getLevelForXP(c.playerXP[GameConstants.STRENGTH]) * 1.2);
+		if (c.playerLevel[GameConstants.STRENGTH] > c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.STRENGTH]) * 1.2 + 1) {
+			c.playerLevel[GameConstants.STRENGTH] = (int) (c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.STRENGTH]) * 1.2);
 		}
 		c.playerLevel[GameConstants.PRAYER] += getBrewStat(5, .10);
-		if (c.playerLevel[GameConstants.PRAYER] > c.getLevelForXP(c.playerXP[GameConstants.PRAYER]) * 1.2 + 1) {
-			c.playerLevel[GameConstants.PRAYER] = (int) (c.getLevelForXP(c.playerXP[GameConstants.PRAYER]) * 1.2);
+		if (c.playerLevel[GameConstants.PRAYER] > c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.PRAYER]) * 1.2 + 1) {
+			c.playerLevel[GameConstants.PRAYER] = (int) (c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.PRAYER]) * 1.2);
 		}
 		c.getPlayerAssistant().refreshSkill(0);
 		c.getPlayerAssistant().refreshSkill(GameConstants.STRENGTH);
@@ -413,14 +413,14 @@ public class Potions {
 					c.playerXP[tD]);
 		}
 		c.playerLevel[GameConstants.DEFENCE] += getBrewStat(1, .20);
-		if (c.playerLevel[GameConstants.DEFENCE] > c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 1.2 + 1) {
-			c.playerLevel[GameConstants.DEFENCE] = (int) (c.getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 1.2);
+		if (c.playerLevel[GameConstants.DEFENCE] > c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 1.2 + 1) {
+			c.playerLevel[GameConstants.DEFENCE] = (int) (c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.DEFENCE]) * 1.2);
 		}
 		c.getPlayerAssistant().refreshSkill(GameConstants.DEFENCE);
 
 		c.playerLevel[GameConstants.HITPOINTS] += getBrewStat(3, .15);
-		if (c.playerLevel[GameConstants.HITPOINTS] > c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS]) * 1.17 + 1) {
-			c.playerLevel[GameConstants.HITPOINTS] = (int) (c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS]) * 1.17);
+		if (c.playerLevel[GameConstants.HITPOINTS] > c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS]) * 1.17 + 1) {
+			c.playerLevel[GameConstants.HITPOINTS] = (int) (c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS]) * 1.17);
 		}
 		c.getPlayerAssistant().refreshSkill(GameConstants.HITPOINTS);
 	}
@@ -442,19 +442,19 @@ public class Potions {
 	}
 
 	public int getBrewStat(int skill, double amount) {
-		return (int) (c.getLevelForXP(c.playerXP[skill]) * amount);
+		return (int) (c.getPlayerAssistant().getLevelForXP(c.playerXP[skill]) * amount);
 	}
 
 	public int getBoostedStat(int skill, boolean sup) {
 		int increaseBy;
 		if (sup) {
-			increaseBy = (int) (c.getLevelForXP(c.playerXP[skill]) * .20);
+			increaseBy = (int) (c.getPlayerAssistant().getLevelForXP(c.playerXP[skill]) * .20);
 		} else {
-			increaseBy = (int) (c.getLevelForXP(c.playerXP[skill]) * .13) + 1;
+			increaseBy = (int) (c.getPlayerAssistant().getLevelForXP(c.playerXP[skill]) * .13) + 1;
 		}
-		if (c.playerLevel[skill] + increaseBy > c
+		if (c.playerLevel[skill] + increaseBy > c.getPlayerAssistant()
 				.getLevelForXP(c.playerXP[skill]) + increaseBy + 1) {
-			return c.getLevelForXP(c.playerXP[skill]) + increaseBy
+			return c.getPlayerAssistant().getLevelForXP(c.playerXP[skill]) + increaseBy
 					- c.playerLevel[skill];
 		}
 		return increaseBy;

--- a/2006Scape Server/src/main/java/com/rs2/game/content/minigames/castlewars/CastleWars.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/content/minigames/castlewars/CastleWars.java
@@ -586,7 +586,7 @@ public class CastleWars {
 			deleteGameItems(player);
 			player.isDead = false;
 			for (int i = 0; i < 25; i++) {
-				player.playerLevel[i] = player
+				player.playerLevel[i] = player.getPlayerAssistant()
 						.getLevelForXP(player.playerXP[i]);
 				player.getPlayerAssistant().refreshSkill(i);
 			}

--- a/2006Scape Server/src/main/java/com/rs2/game/players/Player.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/players/Player.java
@@ -939,13 +939,13 @@ public abstract class Player {
 		if (System.currentTimeMillis() - restoreStatsDelay > 60000) {
 			restoreStatsDelay = System.currentTimeMillis();
 			for (int skill = 0; skill < playerLevel.length; skill++) {
-				if (playerLevel[skill] < getLevelForXP(playerXP[skill])) {
+				if (playerLevel[skill] < playerAssistant.getLevelForXP(playerXP[skill])) {
 					if (skill != 5) { // prayer doesn't restore
 						playerLevel[skill] += 1;
 						getPacketSender().setSkillLevel(skill, playerLevel[skill], playerXP[skill]);
 						getPlayerAssistant().refreshSkill(skill);
 					}
-				} else if (playerLevel[skill] > getLevelForXP(playerXP[skill])) {
+				} else if (playerLevel[skill] > playerAssistant.getLevelForXP(playerXP[skill])) {
 					playerLevel[skill] -= 1;
 					getPacketSender().setSkillLevel(skill, playerLevel[skill], playerXP[skill]);
 					getPlayerAssistant().refreshSkill(skill);
@@ -2543,13 +2543,13 @@ public abstract class Player {
 		if (isBot) {
 			return 0;
 		}
-		int j = getLevelForXP(playerXP[GameConstants.ATTACK]);
-		int k = getLevelForXP(playerXP[GameConstants.DEFENCE]);
-		int l = getLevelForXP(playerXP[GameConstants.STRENGTH]);
-		int i1 = getLevelForXP(playerXP[GameConstants.HITPOINTS]);
-		int j1 = getLevelForXP(playerXP[GameConstants.PRAYER]);
-		int k1 = getLevelForXP(playerXP[GameConstants.RANGED]);
-		int l1 = getLevelForXP(playerXP[GameConstants.MAGIC]);
+		int j = playerAssistant.getLevelForXP(playerXP[GameConstants.ATTACK]);
+		int k = playerAssistant.getLevelForXP(playerXP[GameConstants.DEFENCE]);
+		int l = playerAssistant.getLevelForXP(playerXP[GameConstants.STRENGTH]);
+		int i1 = playerAssistant.getLevelForXP(playerXP[GameConstants.HITPOINTS]);
+		int j1 = playerAssistant.getLevelForXP(playerXP[GameConstants.PRAYER]);
+		int k1 = playerAssistant.getLevelForXP(playerXP[GameConstants.RANGED]);
+		int l1 = playerAssistant.getLevelForXP(playerXP[GameConstants.MAGIC]);
 		int combatLevel = (int) ((k + i1 + Math.floor(j1 / 2)) * 0.25D) + 1;
 		double d = (j + l) * 0.32500000000000001D;
 		double d1 = Math.floor(k1 * 1.5D) * 0.32500000000000001D;
@@ -2562,24 +2562,6 @@ public abstract class Player {
 			combatLevel += d2;
 		}
 		return combatLevel;
-	}
-
-	public int getLevelForXP(int exp) {
-		if (exp > 13034430) {
-			return 99;
-		} else {
-			int points = 0;
-			for (int lvl = 1; lvl <= 99; ++lvl) {
-				points = (int) (points + Math.floor(lvl + 300.0D
-						* Math.pow(2.0D, lvl / 7.0D)));
-				int var5 = (int) Math.floor(points / 4);
-				if (var5 >= exp) {
-					return lvl;
-				}
-			}
-
-			return 99;
-		}
 	}
 
 	private boolean chatTextUpdateRequired = false;
@@ -2720,7 +2702,7 @@ public abstract class Player {
 			isDead = true;
 		}
 		str.writeByteC(playerLevel[GameConstants.HITPOINTS]); // Their current hp, for HP bar
-		str.writeByte(getLevelForXP(playerXP[GameConstants.HITPOINTS]));
+		str.writeByte(playerAssistant.getLevelForXP(playerXP[GameConstants.HITPOINTS]));
 	}
 
 	protected void appendHitUpdate2(Stream str) {
@@ -2738,7 +2720,7 @@ public abstract class Player {
 			isDead = true;
 		}
 		str.writeByte(playerLevel[GameConstants.HITPOINTS]); // Their current hp, for HP bar
-		str.writeByteC(getLevelForXP(playerXP[GameConstants.HITPOINTS])); // Their max hp, for HP
+		str.writeByteC(playerAssistant.getLevelForXP(playerXP[GameConstants.HITPOINTS])); // Their max hp, for HP
 	}
 
 	public void appendPlayerUpdateBlock(Stream str) {
@@ -3120,7 +3102,7 @@ public abstract class Player {
 		if (teleTimer <= 0) {
 			playerLevel[GameConstants.HITPOINTS] -= damage;
 			int difference = playerLevel[GameConstants.HITPOINTS] - damage;
-			if (difference <= getLevelForXP(playerXP[GameConstants.HITPOINTS]) / 10 && difference > 0)
+			if (difference <= playerAssistant.getLevelForXP(playerXP[GameConstants.HITPOINTS]) / 10 && difference > 0)
 				appendRedemption();
 			getPlayerAssistant().handleROL();
 		} else {
@@ -3137,11 +3119,11 @@ public abstract class Player {
 	public void appendRedemption() {
 		Client c = (Client) PlayerHandler.players[playerId];
 		if (c.getPrayer().prayerActive[22]) {
-			int added = c.playerLevel[GameConstants.HITPOINTS] += (int)(c.getLevelForXP(c.playerXP[GameConstants.PRAYER]) * .25);
-			if (added > c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
-				c.playerLevel[GameConstants.HITPOINTS] = c.getLevelForXP(c.playerXP[GameConstants.HITPOINTS]);
+			int added = c.playerLevel[GameConstants.HITPOINTS] += (int)(c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.PRAYER]) * .25);
+			if (added > c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS])) {
+				c.playerLevel[GameConstants.HITPOINTS] = c.getPlayerAssistant().getLevelForXP(c.playerXP[GameConstants.HITPOINTS]);
 			} else {
-				c.playerLevel[GameConstants.HITPOINTS] += (int)(getLevelForXP(c.playerXP[GameConstants.PRAYER]) * .25);
+				c.playerLevel[GameConstants.HITPOINTS] += (int)(playerAssistant.getLevelForXP(c.playerXP[GameConstants.PRAYER]) * .25);
 			}
 			c.playerLevel[GameConstants.PRAYER] = 0;
 			c.getPlayerAssistant().refreshSkill(GameConstants.HITPOINTS);

--- a/2006Scape Server/src/main/java/com/rs2/game/players/PlayerAssistant.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/players/PlayerAssistant.java
@@ -40,7 +40,7 @@ public class PlayerAssistant {
 	}
 	
 	public boolean savePlayer() {
-		return (player.wildLevel < 20 && player.playerEquipment[ItemConstants.RING] == 2570 && player.playerLevel[GameConstants.HITPOINTS] > 0 && player.playerLevel[GameConstants.HITPOINTS] <= player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS]) / 10 && player.underAttackBy > 0);
+		return (player.wildLevel < 20 && player.playerEquipment[ItemConstants.RING] == 2570 && player.playerLevel[GameConstants.HITPOINTS] > 0 && player.playerLevel[GameConstants.HITPOINTS] <= getLevelForXP(player.playerXP[GameConstants.HITPOINTS]) / 10 && player.underAttackBy > 0);
 	}
 	
 	public void handleROL() {
@@ -2040,8 +2040,8 @@ public class PlayerAssistant {
 		int oldLevel = getLevelForXP(player.playerXP[skill]);
 		player.playerXP[skill] += amount;
 		if (oldLevel <= getLevelForXP(player.playerXP[skill])) {
-			if (player.playerLevel[skill] < player.getPlayerAssistant().getLevelForXP(player.playerXP[skill]) && skill != 3 && skill != 5) {
-				player.playerLevel[skill] = player.getPlayerAssistant().getLevelForXP(player.playerXP[skill]);
+			if (player.playerLevel[skill] < getLevelForXP(player.playerXP[skill]) && skill != 3 && skill != 5) {
+				player.playerLevel[skill] = getLevelForXP(player.playerXP[skill]);
 			}
 			levelUp(skill);
 			player.gfx100(199);

--- a/2006Scape Server/src/main/java/com/rs2/game/players/PlayerAssistant.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/players/PlayerAssistant.java
@@ -2034,7 +2034,7 @@ public class PlayerAssistant {
 		}
 		int oldLevel = getLevelForXP(player.playerXP[skill]);
 		player.playerXP[skill] += amount;
-		if (oldLevel <= getLevelForXP(player.playerXP[skill])) {
+		if (oldLevel < getLevelForXP(player.playerXP[skill])) {
 			if (player.playerLevel[skill] < getLevelForXP(player.playerXP[skill]) && skill != 3 && skill != 5) {
 				player.playerLevel[skill] = getLevelForXP(player.playerXP[skill]);
 			}

--- a/2006Scape Server/src/main/java/com/rs2/game/players/PlayerAssistant.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/players/PlayerAssistant.java
@@ -1992,34 +1992,29 @@ public class PlayerAssistant {
 		player.getPacketSender().setSkillLevel(skill, player.playerLevel[skill], player.playerXP[skill]);
 	}
 
-	public int getXPForLevel(int level) {
-		int points = 0;
-		int output = 0;
-
-		for (int lvl = 1; lvl <= level; lvl++) {
-			points += Math.floor(lvl + 300.0 * Math.pow(2.0, lvl / 7.0));
-			if (lvl >= level) {
-				return output;
-			}
+	/* Updated methods for getXPForLevel/getLevelForXP */
+	private static final int[] xp_per_level = new int[100];
+	
+	static {
+		int points = 0, output = 0;
+		for (int lvl = 1; lvl <= 99; lvl++) {
+			xp_per_level[lvl] = output;
+			points += Math.floor(lvl + 300 * Math.pow(2, lvl / 7.0));
 			output = (int) Math.floor(points / 4);
 		}
-		return 0;
+	}
+	
+	public static int getXPForLevel(int level) {
+		return level > 99 ? 200_000_000 : xp_per_level[level];
 	}
 
-	public int getLevelForXP(int exp) {
-		int points = 0;
-		int output = 0;
-		if (exp > 13034430) {
-			return 99;
-		}
-		for (int lvl = 1; lvl <= 99; lvl++) {
-			points += Math.floor(lvl + 300.0 * Math.pow(2.0, lvl / 7.0));
-			output = (int) Math.floor(points / 4);
-			if (output >= exp) {
+	public static int getLevelForXP(int exp) {
+		for (int lvl = 1; lvl <= 98; lvl++) {
+			if (exp < xp_per_level[lvl + 1]) {
 				return lvl;
 			}
 		}
-		return 0;
+		return 99;
 	}
 
 	public boolean addSkillXP(double amount, int skill) {

--- a/2006Scape Server/src/main/java/com/rs2/game/players/PlayerAssistant.java
+++ b/2006Scape Server/src/main/java/com/rs2/game/players/PlayerAssistant.java
@@ -40,7 +40,7 @@ public class PlayerAssistant {
 	}
 	
 	public boolean savePlayer() {
-		return (player.wildLevel < 20 && player.playerEquipment[ItemConstants.RING] == 2570 && player.playerLevel[GameConstants.HITPOINTS] > 0 && player.playerLevel[GameConstants.HITPOINTS] <= player.getLevelForXP(player.playerXP[GameConstants.HITPOINTS]) / 10 && player.underAttackBy > 0);
+		return (player.wildLevel < 20 && player.playerEquipment[ItemConstants.RING] == 2570 && player.playerLevel[GameConstants.HITPOINTS] > 0 && player.playerLevel[GameConstants.HITPOINTS] <= player.getPlayerAssistant().getLevelForXP(player.playerXP[GameConstants.HITPOINTS]) / 10 && player.underAttackBy > 0);
 	}
 	
 	public void handleROL() {
@@ -2040,8 +2040,8 @@ public class PlayerAssistant {
 		int oldLevel = getLevelForXP(player.playerXP[skill]);
 		player.playerXP[skill] += amount;
 		if (oldLevel <= getLevelForXP(player.playerXP[skill])) {
-			if (player.playerLevel[skill] < player.getLevelForXP(player.playerXP[skill]) && skill != 3 && skill != 5) {
-				player.playerLevel[skill] = player.getLevelForXP(player.playerXP[skill]);
+			if (player.playerLevel[skill] < player.getPlayerAssistant().getLevelForXP(player.playerXP[skill]) && skill != 3 && skill != 5) {
+				player.playerLevel[skill] = player.getPlayerAssistant().getLevelForXP(player.playerXP[skill]);
 			}
 			levelUp(skill);
 			player.gfx100(199);

--- a/2006Scape Server/src/main/java/com/rs2/net/packets/impl/Commands.java
+++ b/2006Scape Server/src/main/java/com/rs2/net/packets/impl/Commands.java
@@ -45,9 +45,6 @@ public class Commands implements PacketType {
 
     public static void playerCommands(Player player, String playerCommand, String[] arguments) {
         switch (playerCommand.toLowerCase()) {
-        case "advo":
-        	player.getPlayerAssistant().addSkillXP(83, 0);
-        	break;
             case "link":
                 player.setDiscordCode(arguments[0]);
                 player.getPacketSender().sendMessage("Your Account has now been linked with Discord User ID:");

--- a/2006Scape Server/src/main/java/com/rs2/net/packets/impl/Commands.java
+++ b/2006Scape Server/src/main/java/com/rs2/net/packets/impl/Commands.java
@@ -45,6 +45,9 @@ public class Commands implements PacketType {
 
     public static void playerCommands(Player player, String playerCommand, String[] arguments) {
         switch (playerCommand.toLowerCase()) {
+        case "advo":
+        	player.getPlayerAssistant().addSkillXP(83, 0);
+        	break;
             case "link":
                 player.setDiscordCode(arguments[0]);
                 player.getPacketSender().sendMessage("Your Account has now been linked with Discord User ID:");


### PR DESCRIPTION
Fix for bug introduced with levelup in earlier PR. Only a single method is used for getting the level for XP. The method now also works more effectively. https://github.com/2006-Scape/2006Scape/commit/09068e31d34921fefe152b0aaab80e89f97bdaf3 is a summary of the changes to the methods