### PR TITLE
Fixed dueling NPE

### DIFF
--- a/2006Scape Server/src/main/java/com/rs2/net/packets/impl/AttackPlayer.java
+++ b/2006Scape Server/src/main/java/com/rs2/net/packets/impl/AttackPlayer.java
@@ -32,7 +32,7 @@ public class AttackPlayer implements PacketType {
 			}
 			
 			if (player.inDuelArena() && !player.duelingArena()) {
-				player.getChallengePlayer().processPacket(player, null);
+				player.getChallengePlayer().processPacket(player, packet);
 			}
 
 			if (player.respawnTimer > 0) {


### PR DESCRIPTION
Why was this null? Right clicking player and sending duel request via "Challenge" option produces an NPE, because packet is null, but ChallengePlayer checks packet.getOpcode() value without checking if packet is null first.