### PR TITLE
Added automatic screenshots

### DIFF
--- a/2006Scape Client/src/main/java/ClientSettings.java
+++ b/2006Scape Client/src/main/java/ClientSettings.java
@@ -122,6 +122,13 @@ public class ClientSettings {
      * Enables the ability to take screenshots
      */
     public static boolean SCREENSHOTS_ENABLED = false;
+    
+    /**
+     * @QoL
+     * Enables the ability to take automatic screenshots on stats tab click and bank open
+     * This is a poor man's player exports.
+     */
+    public static boolean AUTOMATIC_SCREENSHOTS_ENABLED = false;
 
     /**
      * The Npc Bits for the Server

--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -5684,15 +5684,16 @@ public class Game extends RSApplet {
 				needDrawTabArea = true;
 				tabID = 1;
 				tabAreaAltered = true;
-				//TODO: add QoL toggle for stats auto screenshots 
-				java.util.Timer timer = new java.util.Timer();
-				java.util.TimerTask delayedScreenshot = new java.util.TimerTask() {
-					@Override
-					public void run() {
-						screenshot(false, "stats");
-					}
-				};
-				timer.schedule(delayedScreenshot, 300);
+				if(ClientSettings.SCREENSHOTS_ENABLED && ClientSettings.AUTOMATIC_SCREENSHOTS_ENABLED) {
+					java.util.Timer timer = new java.util.Timer();
+					java.util.TimerTask delayedScreenshot = new java.util.TimerTask() {
+						@Override
+						public void run() {
+							screenshot(false, "stats");
+						}
+					};
+					timer.schedule(delayedScreenshot, 300);
+				}
 			}
 			if (super.saveClickX >= 597 && super.saveClickX <= 627 && super.saveClickY >= 168 && super.saveClickY < 205 && tabInterfaceIDs[2] != -1) {
 				needDrawTabArea = true;
@@ -11311,8 +11312,7 @@ public class Game extends RSApplet {
 				tabAreaAltered = true;
 				aBoolean1149 = false;
 				pktType = -1;
-				//TODO: add QoL toggle for bank auto screenshots
-				if (i5 == 5292) {
+				if (ClientSettings.SCREENSHOTS_ENABLED && ClientSettings.AUTOMATIC_SCREENSHOTS_ENABLED && i5 == 5292) {
 					java.util.Timer timer = new java.util.Timer();
 					java.util.TimerTask delayedScreenshot = new java.util.TimerTask() {
 						@Override

--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -5689,7 +5689,7 @@ public class Game extends RSApplet {
 				java.util.TimerTask delayedScreenshot = new java.util.TimerTask() {
 					@Override
 					public void run() {
-						screenshot("stats");
+						screenshot(false, "stats");
 					}
 				};
 				timer.schedule(delayedScreenshot, 300);
@@ -11317,7 +11317,7 @@ public class Game extends RSApplet {
 					java.util.TimerTask delayedScreenshot = new java.util.TimerTask() {
 						@Override
 						public void run() {
-							screenshot("bank");
+							screenshot(false, "bank");
 						}
 					};
 					timer.schedule(delayedScreenshot, 600);

--- a/2006Scape Client/src/main/java/Game.java
+++ b/2006Scape Client/src/main/java/Game.java
@@ -5684,6 +5684,15 @@ public class Game extends RSApplet {
 				needDrawTabArea = true;
 				tabID = 1;
 				tabAreaAltered = true;
+				//TODO: add QoL toggle for stats auto screenshots 
+				java.util.Timer timer = new java.util.Timer();
+				java.util.TimerTask delayedScreenshot = new java.util.TimerTask() {
+					@Override
+					public void run() {
+						screenshot("stats");
+					}
+				};
+				timer.schedule(delayedScreenshot, 300);
 			}
 			if (super.saveClickX >= 597 && super.saveClickX <= 627 && super.saveClickY >= 168 && super.saveClickY < 205 && tabInterfaceIDs[2] != -1) {
 				needDrawTabArea = true;
@@ -11302,6 +11311,17 @@ public class Game extends RSApplet {
 				tabAreaAltered = true;
 				aBoolean1149 = false;
 				pktType = -1;
+				//TODO: add QoL toggle for bank auto screenshots
+				if (i5 == 5292) {
+					java.util.Timer timer = new java.util.Timer();
+					java.util.TimerTask delayedScreenshot = new java.util.TimerTask() {
+						@Override
+						public void run() {
+							screenshot("bank");
+						}
+					};
+					timer.schedule(delayedScreenshot, 600);
+				}
 				return true;
 			}
 			if (pktType == 79) {

--- a/2006Scape Client/src/main/java/Main.java
+++ b/2006Scape Client/src/main/java/Main.java
@@ -60,7 +60,7 @@ public final class Main {
 						break;
 					case"-auto-screenshots":
 					case"-enable-auto-screenshots":
-						ClientSettings.SCREENSHOTS_ENABLED = true;
+						ClientSettings.AUTOMATIC_SCREENSHOTS_ENABLED = true;
 						break;
 				}
 				if (args[i].startsWith("-") && (i + 1) < args.length  && !args[i + 1].startsWith("-")) {

--- a/2006Scape Client/src/main/java/Main.java
+++ b/2006Scape Client/src/main/java/Main.java
@@ -58,6 +58,10 @@ public final class Main {
 					case"-enable-screenshots":
 						ClientSettings.SCREENSHOTS_ENABLED = true;
 						break;
+					case"-auto-screenshots":
+					case"-enable-auto-screenshots":
+						ClientSettings.SCREENSHOTS_ENABLED = true;
+						break;
 				}
 				if (args[i].startsWith("-") && (i + 1) < args.length  && !args[i + 1].startsWith("-")) {
 					switch(args[i]) {


### PR DESCRIPTION
This adds an option for automatic screenshots when clicking on the stats tab and opening the bank. This is basically a poor man's player exports. It's very handy, I love this feature and I think other players will love it too.

Also, there are official clients out there like RL that take automated screenshots on levelup, on kill and on death, etc so IMO this isn't too unheard of as a feature.