### PR TITLE
Added scripts to use the Server+Client on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 2. Run `setup.sh` (./setup.sh) or `mvn -B clean install`
 
-3. Oprn another Terminal and `run_server.sh` (./run_server.sh)
+3. Open another Terminal and `run_server.sh` (./run_server.sh)
 
 4. Run `run_client.sh` (./run_client.sh)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Client/Launcher Download: https://2006Scape.org/
 ### Rune-Server project thread: [Project thread](https://www.rune-server.ee/runescape-development/rs2-server/projects/686444-2006rebotted-remake-server-will-allow-supply-creatable-bots.html)
 
-# Installation + Running (Developers)
+# Installation + Running (Developers) with IntelliJ
 
 1. Import Project in IntelliJ
 
@@ -17,6 +17,14 @@
 
    [(You Can Also Run The Server With The -c/-config Argument)](https://wiki.2006scape.org/books/getting-setup/page/server-arguments)
 5. Navigate to `2006Scape Client` > `src` > `main` > `java`, right click Client and hit Run [Image](https://i.imgur.com/gSmqGLn.png)
+
+# Installation + Running (Developers) with Terminal
+
+1. Run setup.sh (./setup.sh)
+
+2. Oprn another Terminal and run_server.sh
+
+3. run_client.sh
 
 *Advanced*
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@
 
 # Installation + Running (Developers) with Terminal
 
-1. Run setup.sh (./setup.sh) or `mvn -B clean install`
+1. Install *Java* (java) and *Maven* (mvn)
 
-2. Oprn another Terminal and `run_server.sh` (./run_server.sh)
+2. Run `setup.sh` (./setup.sh) or `mvn -B clean install`
 
-3. Run `run_client.sh` (./run_client.sh)
+3. Oprn another Terminal and `run_server.sh` (./run_server.sh)
+
+4. Run `run_client.sh` (./run_client.sh)
 
 ## Using Parabot with your local server:
 - **1:** Download the latest Parabot Client from [here](https://github.com/2006-Scape/Parabot/releases)

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
 
 1. Run setup.sh (./setup.sh) or `mvn -B clean install`
 
-2. Oprn another Terminal and run_server.sh (./run_server.sh)
+2. Oprn another Terminal and `run_server.sh` (./run_server.sh)
 
-3. Run run_client.sh (./run_client.sh)
+3. Run `run_client.sh` (./run_client.sh)
 
 ## Using Parabot with your local server:
 - **1:** Download the latest Parabot Client from [here](https://github.com/2006-Scape/Parabot/releases)

--- a/README.md
+++ b/README.md
@@ -20,15 +20,11 @@
 
 # Installation + Running (Developers) with Terminal
 
-1. Run setup.sh (./setup.sh)
+1. Run setup.sh (./setup.sh) or `mvn -B clean install`
 
-2. Oprn another Terminal and run_server.sh
+2. Oprn another Terminal and run_server.sh (./run_server.sh)
 
-3. run_client.sh
-
-*Advanced*
-
-To compile any module from the command line, run `mvn clean install`
+3. Run run_client.sh (./run_client.sh)
 
 ## Using Parabot with your local server:
 - **1:** Download the latest Parabot Client from [here](https://github.com/2006-Scape/Parabot/releases)

--- a/run_client.sh
+++ b/run_client.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-cd "2006 Client"
+cd "2006Scape Client"
 #mvn package
 java -jar "target/client-1.0-jar-with-dependencies.jar" -s localhost

--- a/run_client.sh
+++ b/run_client.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 cd "2006Scape Client"
-#mvn package
 java -jar "target/client-1.0-jar-with-dependencies.jar" -s localhost

--- a/run_client.sh
+++ b/run_client.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd "2006 Client"
+#mvn package
+java -jar "target/client-1.0-jar-with-dependencies.jar" -s localhost

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-cd "2006 Server"
+cd "2006Scape Server"
 #mvn package
 java -jar "target/server-1.0-jar-with-dependencies.jar" -c ServerConfig.Sample.json -gui

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd "2006 Server"
+#mvn package
+java -jar "target/server-1.0-jar-with-dependencies.jar" -c ServerConfig.Sample.json -gui

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 cd "2006Scape Server"
-#mvn package
 java -jar "target/server-1.0-jar-with-dependencies.jar" -c ServerConfig.Sample.json -gui

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+mvn -B clean install
+
+cd "2006 Server"
+mvn package
+
+cd ..
+
+cd "2006 Client"
+mvn package

--- a/setup.sh
+++ b/setup.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 mvn -B clean install
 
-cd "2006 Server"
+cd "2006Scape Server"
 mvn package
 
 cd ..
 
-cd "2006 Client"
+cd "2006Scape Client"
 mvn package

--- a/setup.sh
+++ b/setup.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 mvn -B clean install
 
-cd "2006Scape Server"
-mvn package
+#cd "2006Scape Server"
+#mvn package
 
-cd ..
+#cd ..
 
-cd "2006Scape Client"
-mvn package
+#cd "2006Scape Client"
+#mvn package


### PR DESCRIPTION
I added a setup(.sh), run_server(.sh) and run_client(.sh) scripts to allow Linux users to easily setup and run everything, plus instructions on the README.md file.